### PR TITLE
✨ feat: v0.5.0 — agent trust model (audit / queue / direct)

### DIFF
--- a/docs/agent-trust-model/README.md
+++ b/docs/agent-trust-model/README.md
@@ -116,6 +116,15 @@ An independent audit of the write path, plus adversarial testing, turned up defe
 
 **Residual, filed for a later release:** note content containing a literal `## Edit History` line is handled by v2, but the broader principle — that the on-disk format should escape rather than length-delimit — is left as a possible future refactor. v2 closes the exploit; the format is not changing again in v0.5.
 
+## Deferred follow-ups
+
+Non-blocking items from the final whole-branch review, to pick up in a later release:
+
+- **Record `approvedBy` on an approved *edit*, not just an approved create.** Parity gap: an edit-approve attributes the note to the approver as author but doesn't set `approvedBy`. Recording it means threading the field through `updateNote` (a routed, security-sensitive path), which is the reason not to rush it.
+- **Give a restore its own history action.** Un-delete currently records `action: 'edited'`; a dedicated `'restored'` would keep the edit-revert `history[length-2]` heuristic exact as non-edit history entries accumulate. Harmless today.
+- **Length-delimit proposal frontmatter** (`ProposalStore`) the way note storage now is. Theoretical — it needs a real newline-named file, which `create_note`'s existence check blocks first — but it's the one spot the "content can't forge structure" invariant isn't mirrored.
+- **Empty/whitespace-only-content notes vanish on reload** (`isValidNote` requires truthy content). Pre-existing, predates v0.5, orthogonal to the trust model.
+
 ## Out of scope
 
 - **3-way merge for stale proposals** — v0.5 ships simple-pick (spec §7.6). Add a real merge only if conflicts prove common.

--- a/docs/agent-trust-model/README.md
+++ b/docs/agent-trust-model/README.md
@@ -15,20 +15,20 @@ v0.4 gave agents write access to workspace notes. v0.5 gives that access an off 
 
 #### Tasks
 
-- [ ] Add `AgentWriteMode` (`direct` | `audit` | `queue`) and `WorkspaceConfig` types (plan Task 2)
-- [ ] Read/write `.code-notes/config.json`, tolerant of malformed input (plan Task 2)
-- [ ] Add the `codeContextNotes.agentWriteMode` setting and mirror it into config.json (plan Task 8)
-- [ ] Route agent writes by mode in `NoteManager` (plan Tasks 4, 5)
-- [ ] Re-read the mode per MCP call so a mode change needs no server restart (plan Task 7)
+- [x] Add `AgentWriteMode` (`direct` | `audit` | `queue`) and `WorkspaceConfig` types (plan Task 2)
+- [x] Read/write `.code-notes/config.json`, tolerant of malformed input (plan Task 2)
+- [x] Add the `codeContextNotes.agentWriteMode` setting and mirror it into config.json (plan Task 8)
+- [x] Route agent writes by mode in `NoteManager` (plan Tasks 4, 5)
+- [x] Re-read the mode per MCP call so a mode change needs no server restart (plan Task 7)
 
 #### Acceptance Criteria
 
-- [ ] The mode is read from `.code-notes/config.json` by both the extension and the standalone MCP server
-- [ ] There is **no** `--write-mode` CLI flag — an agent cannot choose its own mode
-- [ ] Changing the setting in VS Code updates `config.json` without a reload
-- [ ] A running MCP server honors a mode change on its next call, with no restart
-- [ ] A malformed or missing `config.json` falls back to `audit` and never breaks note-taking
-- [ ] Human writes are unaffected in every mode (detection is `authorType: 'agent'`, never author-name sniffing)
+- [x] The mode is read from `.code-notes/config.json` by both the extension and the standalone MCP server
+- [x] There is **no** `--write-mode` CLI flag — an agent cannot choose its own mode
+- [x] Changing the setting in VS Code updates `config.json` without a reload
+- [x] A running MCP server honors a mode change on its next call, with no restart
+- [x] A malformed or missing `config.json` falls back to `audit` and never breaks note-taking
+- [x] Human writes are unaffected in every mode (detection is `authorType: 'agent'`, never author-name sniffing)
 
 ---
 
@@ -40,22 +40,22 @@ v0.4 gave agents write access to workspace notes. v0.5 gives that access an off 
 
 #### Tasks
 
-- [ ] Append every agent op to `.code-notes/_audit.log` (JSONL) in `audit` mode (plan Tasks 3, 4)
-- [ ] Rotate the log at the retention cap, under a lock (plan Task 3)
-- [ ] Add the "Agent activity" sidebar view listing the last 50 ops (plan Task 9)
-- [ ] Add inline Revert, Open note, and the `Code Notes: Truncate Audit Log` command (plan Task 9)
-- [ ] Watch `_audit.log` so the view refreshes on external writes (plan Task 8)
+- [x] Append every agent op to `.code-notes/_audit.log` (JSONL) in `audit` mode (plan Tasks 3, 4)
+- [x] Rotate the log at the retention cap, under a lock (plan Task 3)
+- [x] Add the "Agent activity" sidebar view listing the last 50 ops (plan Task 9)
+- [x] Add inline Revert, Open note, and the `Code Notes: Truncate Audit Log` command (plan Task 9)
+- [x] Watch `_audit.log` so the view refreshes on external writes (plan Task 8)
 
 #### Acceptance Criteria
 
-- [ ] `audit` is the default mode
-- [ ] Agent writes still land immediately in `audit` mode — logging never blocks the agent
-- [ ] Each entry shows the op, file, agent name, and time
-- [ ] Revert on a `create` deletes the note; on an `edit`/`delete` it restores the prior content from `history[]`
-- [ ] The view refreshes when an agent in another process writes, with no window reload
-- [ ] A corrupt log line is skipped with one warning — the view still renders, nothing crashes
-- [ ] The log rotates to `_audit.log.1` past the retention cap; no entry is lost
-- [ ] Concurrent appends from several agent processes never interleave into a torn line
+- [x] `audit` is the default mode
+- [x] Agent writes still land immediately in `audit` mode — logging never blocks the agent
+- [x] Each entry shows the op, file, agent name, and time
+- [x] Revert on a `create` deletes the note; on an `edit`/`delete` it restores the prior content from `history[]`
+- [x] The view refreshes when an agent in another process writes, with no window reload
+- [x] A corrupt log line is skipped with one warning — the view still renders, nothing crashes
+- [x] The log rotates to `_audit.log.1` past the retention cap; no entry is lost
+- [x] Concurrent appends from several agent processes never interleave into a torn line
 
 ---
 
@@ -67,24 +67,24 @@ v0.4 gave agents write access to workspace notes. v0.5 gives that access an off 
 
 #### Tasks
 
-- [ ] Add `Proposal` type and `ProposalStore` over `.code-notes/_pending/` (plan Task 5)
-- [ ] Divert agent writes to proposals in `queue` mode; return the pending shape from MCP tools (plan Tasks 5, 7)
-- [ ] Add the "Pending agent proposals" view with Approve / Reject / Edit-and-approve (plan Task 10)
-- [ ] Detect stale targets via `targetContentHash` and offer simple-pick (plan Task 10)
-- [ ] Flag orphaned proposals whose target note is gone (plan Task 10)
-- [ ] Prompt about stranded proposals when leaving `queue` mode (plan Task 10)
+- [x] Add `Proposal` type and `ProposalStore` over `.code-notes/_pending/` (plan Task 5)
+- [x] Divert agent writes to proposals in `queue` mode; return the pending shape from MCP tools (plan Tasks 5, 7)
+- [x] Add the "Pending agent proposals" view with Approve / Reject / Edit-and-approve (plan Task 10)
+- [x] Detect stale targets via `targetContentHash` and offer simple-pick (plan Task 10)
+- [x] Flag orphaned proposals whose target note is gone (plan Task 10)
+- [x] Prompt about stranded proposals when leaving `queue` mode (plan Task 10)
 
 #### Acceptance Criteria
 
-- [ ] In `queue` mode an agent write creates **no** note — only a file in `_pending/`
-- [ ] Write tools return `{ status: "pending", proposalId, message }` — a success shape, not an error, so agents don't retry-loop
-- [ ] Proposals never load as notes (`_pending/` is a subdirectory; the note loader reads only the top level)
-- [ ] Approve applies the note attributed to the approver, with `approvedBy` recorded and round-tripped to disk
-- [ ] Edit-and-approve applies the human's edited text, not the agent's original
-- [ ] Reject moves the file to `_pending/.rejected/` — nothing is silently destroyed
-- [ ] If the target note changed since the proposal, the human is shown both versions and picks one
-- [ ] A proposal whose target note no longer exists is shown as orphaned and can only be rejected
-- [ ] Turning `queue` mode off with proposals pending prompts to review or reject them
+- [x] In `queue` mode an agent write creates **no** note — only a file in `_pending/`
+- [x] Write tools return `{ status: "pending", proposalId, message }` — a success shape, not an error, so agents don't retry-loop
+- [x] Proposals never load as notes (`_pending/` is a subdirectory; the note loader reads only the top level)
+- [x] Approve applies the note attributed to the approver, with `approvedBy` recorded and round-tripped to disk
+- [x] Edit-and-approve applies the human's edited text, not the agent's original
+- [x] Reject moves the file to `_pending/.rejected/` — nothing is silently destroyed
+- [x] If the target note changed since the proposal, the human is shown both versions and picks one
+- [x] A proposal whose target note no longer exists is shown as orphaned and can only be rejected
+- [x] Turning `queue` mode off with proposals pending prompts to review or reject them
 
 ---
 
@@ -96,14 +96,25 @@ v0.4 gave agents write access to workspace notes. v0.5 gives that access an off 
 
 #### Tasks
 
-- [ ] Lock and re-read inside `updateNotePositions` (plan Task 6)
+- [x] Lock and re-read inside `updateNotePositions` (plan Task 6)
 
 #### Acceptance Criteria
 
-- [ ] Repositioning a note never writes stale content over a concurrent edit
-- [ ] The extension's 176 integration tests still pass — repositioning is on the document-change hot path
+- [x] Repositioning a note never writes stale content over a concurrent edit
+- [x] The extension's 178 integration tests still pass — repositioning is on the document-change hot path
 
 ---
+
+## Trust-boundary hardening (found during implementation)
+
+An independent audit of the write path, plus adversarial testing, turned up defects that the trust model depends on but the stories above don't name. All fixed and regression-tested:
+
+- **Agent-write identity comes from the writer, not the note.** An earlier cut keyed off the note's `authorType`, letting an agent edit or delete any *human*-authored note in `queue` mode with no approval. Identity is now a property of the NoteManager instance (the server is the agent, the extension is the human), fail-closed.
+- **Note content can't forge note structure.** Content is agent-controlled input, and the on-disk markdown used unescaped section delimiters — so a note whose body was `**Status:** DELETED` or `## Edit History` deleted itself or forged history on reload (poisoning Revert). Storage is now a versioned, length-delimited format (`**Format:** 2`); pre-v0.5 notes read via the legacy parser and migrate on next save.
+- **The audit log never loses an entry under load.** Rotation is atomic (rename, not rewrite), and appends are lock-free — an earlier lock-on-append design silently dropped entries when the lock budget was exhausted.
+- **The two unrouted write paths (`updateNoteMetadata`, `updateNotePositions`) fail closed for agents** so a future agent-facing caller can't bypass the rails.
+
+**Residual, filed for a later release:** note content containing a literal `## Edit History` line is handled by v2, but the broader principle — that the on-disk format should escape rather than length-delimit — is left as a possible future refactor. v2 closes the exploit; the format is not changing again in v0.5.
 
 ## Out of scope
 

--- a/docs/agent-trust-model/README.md
+++ b/docs/agent-trust-model/README.md
@@ -116,14 +116,14 @@ An independent audit of the write path, plus adversarial testing, turned up defe
 
 **Residual, filed for a later release:** note content containing a literal `## Edit History` line is handled by v2, but the broader principle — that the on-disk format should escape rather than length-delimit — is left as a possible future refactor. v2 closes the exploit; the format is not changing again in v0.5.
 
-## Deferred follow-ups
+## Review follow-ups (addressed in this release)
 
-Non-blocking items from the final whole-branch review, to pick up in a later release:
+The final whole-branch review flagged four non-blocking items; all were fixed before release rather than deferred:
 
-- **Record `approvedBy` on an approved *edit*, not just an approved create.** Parity gap: an edit-approve attributes the note to the approver as author but doesn't set `approvedBy`. Recording it means threading the field through `updateNote` (a routed, security-sensitive path), which is the reason not to rush it.
-- **Give a restore its own history action.** Un-delete currently records `action: 'edited'`; a dedicated `'restored'` would keep the edit-revert `history[length-2]` heuristic exact as non-edit history entries accumulate. Harmless today.
-- **Length-delimit proposal frontmatter** (`ProposalStore`) the way note storage now is. Theoretical — it needs a real newline-named file, which `create_note`'s existence check blocks first — but it's the one spot the "content can't forge structure" invariant isn't mirrored.
-- **Empty/whitespace-only-content notes vanish on reload** (`isValidNote` requires truthy content). Pre-existing, predates v0.5, orthogonal to the trust model.
+- **`approvedBy` is recorded on an approved *edit*,** not just an approved create — threaded through `updateNote`, and not exposed by the MCP `edit_note` tool so an agent can't forge it.
+- **Un-delete records history action `'restored'`** instead of masquerading as `'edited'`.
+- **Proposal frontmatter is hardened:** a `file` value's newline can no longer split it (free-text scalars are JSON-encoded) — the last spot the note store's "content can't forge structure" invariant wasn't mirrored.
+- **Empty-content notes survive reload** (`isValidNote` accepts empty-string content but still rejects a missing content section, so real corruption isn't masked).
 
 ## Out of scope
 

--- a/docs/agent-trust-model/README.md
+++ b/docs/agent-trust-model/README.md
@@ -51,7 +51,7 @@ v0.4 gave agents write access to workspace notes. v0.5 gives that access an off 
 - [x] `audit` is the default mode
 - [x] Agent writes still land immediately in `audit` mode — logging never blocks the agent
 - [x] Each entry shows the op, file, agent name, and time
-- [x] Revert on a `create` deletes the note; on an `edit`/`delete` it restores the prior content from `history[]`
+- [x] Revert on a `create` deletes the note; on an `edit` it restores the prior content from `history[]`; on a `delete` it restores the note
 - [x] The view refreshes when an agent in another process writes, with no window reload
 - [x] A corrupt log line is skipped with one warning — the view still renders, nothing crashes
 - [x] The log rotates to `_audit.log.1` past the retention cap; no entry is lost

--- a/docs/changelogs/v0.5.0.md
+++ b/docs/changelogs/v0.5.0.md
@@ -10,7 +10,7 @@ v0.5 puts you in control of agent-authored notes. A single workspace setting pic
   - The server re-reads the mode per call, so changing it takes effect with no restart.
 - **`audit` mode + Agent activity view**
   - Every agent op appends to `.code-notes/_audit.log` (JSONL) without blocking the write.
-  - The **Agent activity** sidebar lists recent ops with an inline **Revert** (a create reverses to a delete; an edit/delete restores from history), Open note, and a `Code Notes: Truncate Audit Log` command.
+  - The **Agent activity** sidebar lists recent ops with an inline **Revert** (a create reverses to a delete, an edit restores the prior content, a delete restores the note), Open note, and a `Code Notes: Truncate Audit Log` command.
   - The log rotates atomically to `_audit.log.1` past `auditLogRetention` — no entry is lost, even under concurrent writes from several agent processes.
 - **`queue` mode + Pending agent proposals view**
   - Agent writes don't touch live notes; each becomes a proposal in `.code-notes/_pending/`. Write tools return `{ "status": "pending", proposalId }` — a success shape, not an error, so agents don't retry-loop.

--- a/docs/changelogs/v0.5.0.md
+++ b/docs/changelogs/v0.5.0.md
@@ -19,11 +19,16 @@ v0.5 puts you in control of agent-authored notes. A single workspace setting pic
 
 ### Fixed
 - **Note repositioning locks and re-reads** (carried over from v0.4) — following an editor's document changes could overwrite a note edited concurrently by another process with stale content. It now re-reads inside the lock.
+- **Audit-mode Revert of a delete works** — restoring a deleted note (its content survives the soft-delete), where an earlier cut couldn't see or restore it.
+- **Empty-content notes survive reload** instead of vanishing; a note file with a genuinely missing content section is still rejected as corrupt.
+- **Approved edits are attributed** — approving an agent's queued *edit* records `approvedBy`, matching an approved create.
+- **A restore is named as such** — reverting an agent's delete records history action `restored` rather than disguising it as an `edited` entry.
 
 ### Security
 - **Agent-write identity comes from the writer, not the note.** In `queue` mode an agent could previously edit or delete any *human*-authored note with no approval, because the rails keyed off the note's author. Identity is now a property of the writer (the server is the agent, the extension is the human), and fails closed.
 - **Note content can no longer forge note structure.** Content is agent-controlled input, and the on-disk markdown used unescaped delimiters — a note whose body was `**Status:** DELETED` or `## Edit History` could delete itself or forge history entries on reload, poisoning Revert. Storage is now a length-delimited format.
 - **The audit log never drops an entry under load** — rotation is atomic (rename, not rewrite) and appends are lock-free.
+- **A proposal's `file` value can't split its frontmatter.** `file` is agent-controllable via `create_note`, and a newline plus `---` in it could close the proposal frontmatter early and hijack the fields below; the free-text scalar fields are now JSON-encoded.
 
 ### Settings
 - `codeContextNotes.agentWriteMode` — `direct` | `audit` | `queue` (default `audit`), mirrored to `.code-notes/config.json`
@@ -37,7 +42,7 @@ v0.5 puts you in control of agent-authored notes. A single workspace setting pic
 - Existing notes and workflows are otherwise unaffected.
 
 ### Testing
-- 430 tests across packages: core 159, MCP server 74, extension 19 unit + 178 integration. Includes an independent trust-boundary audit and adversarial injection tests (content forging `## Edit History`/`**Status:**`, history fence breakout), a frozen v1-note migration gate, cross-process audit-log race tests, and mutation-checked regression guards for every security fix.
+- 438 tests across packages: core 167, MCP server 74, extension 19 unit + 178 integration. Includes an independent trust-boundary audit and adversarial injection tests (content forging `## Edit History`/`**Status:**`, history fence breakout, proposal-frontmatter injection), a frozen v1-note migration gate, cross-process audit-log race tests, and mutation-checked regression guards for every security fix.
 
 ### Technical
 - Trust routing lives in `@jnahian/code-notes-core`: `NoteManager` consults a per-call `agentWriteMode` and routes agent writes to `AuditLog` (audit) or `ProposalStore` (queue), or straight through (direct). Detection is the writer's identity, never author-string sniffing.

--- a/docs/changelogs/v0.5.0.md
+++ b/docs/changelogs/v0.5.0.md
@@ -1,0 +1,52 @@
+# Changelog - Version 0.5.0
+
+## [0.5.0] - 2026-07-17
+
+v0.5 puts you in control of agent-authored notes. A single workspace setting picks how writes from MCP agents are handled — land immediately (`direct`), land and get logged (`audit`, the new default), or wait for your approval (`queue`) — with two sidebar views for reviewing and undoing agent activity.
+
+### Added
+- **Agent write modes** (`codeContextNotes.agentWriteMode`: `direct` | `audit` | `queue`)
+  - Stored in `.code-notes/config.json` so the standalone MCP server reads the same policy — the VS Code setting is its UI. There is deliberately no server flag for the mode: an agent that picks its own rails has none.
+  - The server re-reads the mode per call, so changing it takes effect with no restart.
+- **`audit` mode + Agent activity view**
+  - Every agent op appends to `.code-notes/_audit.log` (JSONL) without blocking the write.
+  - The **Agent activity** sidebar lists recent ops with an inline **Revert** (a create reverses to a delete; an edit/delete restores from history), Open note, and a `Code Notes: Truncate Audit Log` command.
+  - The log rotates atomically to `_audit.log.1` past `auditLogRetention` — no entry is lost, even under concurrent writes from several agent processes.
+- **`queue` mode + Pending agent proposals view**
+  - Agent writes don't touch live notes; each becomes a proposal in `.code-notes/_pending/`. Write tools return `{ "status": "pending", proposalId }` — a success shape, not an error, so agents don't retry-loop.
+  - The **Pending agent proposals** sidebar offers **Approve / Reject / Edit-and-approve**. Approve attributes the note to you and records `approvedBy`; Reject moves the file to `_pending/.rejected/` for audit.
+  - A note edited after its proposal was made triggers a simple-pick (yours vs. the agent's); a proposal whose target note is gone is flagged orphaned and can only be rejected. Leaving `queue` mode with proposals pending prompts to review or reject them.
+
+### Fixed
+- **Note repositioning locks and re-reads** (carried over from v0.4) — following an editor's document changes could overwrite a note edited concurrently by another process with stale content. It now re-reads inside the lock.
+
+### Security
+- **Agent-write identity comes from the writer, not the note.** In `queue` mode an agent could previously edit or delete any *human*-authored note with no approval, because the rails keyed off the note's author. Identity is now a property of the writer (the server is the agent, the extension is the human), and fails closed.
+- **Note content can no longer forge note structure.** Content is agent-controlled input, and the on-disk markdown used unescaped delimiters — a note whose body was `**Status:** DELETED` or `## Edit History` could delete itself or forge history entries on reload, poisoning Revert. Storage is now a length-delimited format.
+- **The audit log never drops an entry under load** — rotation is atomic (rename, not rewrite) and appends are lock-free.
+
+### Settings
+- `codeContextNotes.agentWriteMode` — `direct` | `audit` | `queue` (default `audit`), mirrored to `.code-notes/config.json`
+- `codeContextNotes.agentAllowList` — informational list of agent names (not a security boundary)
+- `codeContextNotes.auditLogRetention` — entries kept before rotating to `_audit.log.1` (default 1000)
+
+### Compatibility
+- **`audit` is the default — a behavior change for upgraders.** A workspace that already has notes gains a `.code-notes/config.json`, and agent writes begin logging to `.code-notes/_audit.log` unless you set the mode to `direct`. A workspace with no notes is untouched until it has some. Set `agentWriteMode` to `direct` for the pre-v0.5 behavior.
+- **Notes migrate to a new on-disk format (`**Format:** 2`) on next save.** Existing notes are read by the legacy parser and are unchanged until re-saved; no manual migration.
+- **Upgrade the MCP server alongside the extension.** A v0.4 server against a v0.5 workspace ignores `config.json` and behaves as `direct` — it won't honor `audit`/`queue`.
+- Existing notes and workflows are otherwise unaffected.
+
+### Testing
+- 430 tests across packages: core 159, MCP server 74, extension 19 unit + 178 integration. Includes an independent trust-boundary audit and adversarial injection tests (content forging `## Edit History`/`**Status:**`, history fence breakout), a frozen v1-note migration gate, cross-process audit-log race tests, and mutation-checked regression guards for every security fix.
+
+### Technical
+- Trust routing lives in `@jnahian/code-notes-core`: `NoteManager` consults a per-call `agentWriteMode` and routes agent writes to `AuditLog` (audit) or `ProposalStore` (queue), or straight through (direct). Detection is the writer's identity, never author-string sniffing.
+- Versioned storage format: v2 length-delimits the content region (`**Content Lines:** N`) and each history entry (` ```lines=N `) so agent-controlled text can never be re-parsed as structure; the untouched v1 parser reads pre-v0.5 notes.
+- The extension mirrors its settings into `config.json`, and its `.code-notes/` watcher routes `_pending/` and `_audit.log` to the new views instead of the note cache.
+
+### Coming Next
+- v0.6 may add a 3-way merge for conflicting proposals (v0.5 ships simple-pick), and bulk re-tagging if note curation friction proves real.
+
+---
+
+[0.5.0]: https://github.com/jnahian/code-context-notes/releases/tag/v0.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -10686,7 +10686,7 @@
     },
     "packages/code-notes-core": {
       "name": "@jnahian/code-notes-core",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "uuid": "^14.0.0"
@@ -10700,10 +10700,10 @@
     },
     "packages/code-notes-mcp": {
       "name": "@jnahian/code-notes-mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@jnahian/code-notes-core": "0.1.0",
+        "@jnahian/code-notes-core": "0.2.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "diff": "^5.2.0",
         "zod": "^4.4.3"
@@ -10729,10 +10729,10 @@
     },
     "packages/extension": {
       "name": "code-context-notes",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@jnahian/code-notes-core": "0.1.0",
+        "@jnahian/code-notes-core": "0.2.0",
         "uuid": "^14.0.0"
       },
       "devDependencies": {

--- a/packages/code-notes-core/package.json
+++ b/packages/code-notes-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jnahian/code-notes-core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Shared core for Code Context Notes — schema, storage, exports, lock manager.",
   "license": "MIT",
   "type": "module",
@@ -12,7 +12,11 @@
       "default": "./dist/index.js"
     }
   },
-  "files": ["dist", "README.md", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc -p ./",
     "compile:tsc": "tsc -p ./ --noEmit",

--- a/packages/code-notes-core/src/auditLog.ts
+++ b/packages/code-notes-core/src/auditLog.ts
@@ -33,8 +33,37 @@ export class AuditLog {
 
   async append(entry: AuditEntry): Promise<void> {
     await fs.mkdir(path.dirname(this.logPath), { recursive: true });
-    await fs.appendFile(this.logPath, `${JSON.stringify(entry)}\n`, 'utf-8');
-    await this.rotateIfNeeded();
+    const line = `${JSON.stringify(entry)}\n`;
+    const lock = this.opts.lockManager;
+
+    // The append must share the rotation's critical section. A lock only
+    // orders writers that take it: a lock-free append landing between
+    // rotation's read and its truncating write is silently dropped.
+    let appended = false;
+    const writeThenRotate = async () => {
+      await fs.appendFile(this.logPath, line, 'utf-8');
+      appended = true;
+      try {
+        await this.rotate();
+      } catch (e) {
+        // A missed rotation is a log that grows; failing here would fail the
+        // agent's note write. A long log is the lesser evil.
+        console.warn(`[code-notes-core] audit log rotation skipped: ${(e as Error).message}`);
+      }
+    };
+
+    if (!lock) return writeThenRotate();
+
+    try {
+      await lock.withLock(ROTATE_LOCK_ID, writeThenRotate);
+    } catch (e) {
+      if (appended) throw e;
+      // Couldn't get the lock (or it broke). Never cost an agent its write
+      // over the audit lock: append lock-free. O_APPEND is atomic, so the
+      // line lands; only a rotation racing this exact moment could miss it.
+      console.warn(`[code-notes-core] audit append fell back to lock-free: ${(e as Error).message}`);
+      await fs.appendFile(this.logPath, line, 'utf-8');
+    }
   }
 
   /** Newest-first. Tolerant: unparseable lines are skipped, not fatal. */
@@ -69,32 +98,25 @@ export class AuditLog {
   }
 
   /**
-   * Rotation is read-modify-write: another process appending between our read
-   * and our rewrite would lose its line. Hold the lock across the whole thing
-   * and re-read inside it.
+   * Trim the log to the retention cap, moving the overflow to `<log>.1`.
+   *
+   * Read-modify-write, and deliberately NOT self-locking: append() calls this
+   * inside the lock it already holds, and LockManager is not reentrant —
+   * taking it again here would deadlock until lock_timeout. Never call this
+   * outside that critical section.
    */
-  private async rotateIfNeeded(): Promise<void> {
-    const run = async () => {
-      let raw: string;
-      try {
-        raw = await fs.readFile(this.logPath, 'utf-8');
-      } catch {
-        return;
-      }
-      const lines = raw.split('\n').filter(l => l.trim());
-      if (lines.length <= this.retention) return;
-
-      const overflow = lines.length - this.retention;
-      await fs.appendFile(`${this.logPath}.1`, `${lines.slice(0, overflow).join('\n')}\n`, 'utf-8');
-      await fs.writeFile(this.logPath, `${lines.slice(overflow).join('\n')}\n`, 'utf-8');
-    };
-
+  private async rotate(): Promise<void> {
+    let raw: string;
     try {
-      await (this.opts.lockManager ? this.opts.lockManager.withLock(ROTATE_LOCK_ID, run) : run());
-    } catch (e) {
-      // A missed rotation is a log that grows; a thrown error here would fail
-      // the agent's write. Losing the write is worse than a long log.
-      console.warn(`[code-notes-core] audit log rotation skipped: ${(e as Error).message}`);
+      raw = await fs.readFile(this.logPath, 'utf-8');
+    } catch {
+      return;
     }
+    const lines = raw.split('\n').filter(l => l.trim());
+    if (lines.length <= this.retention) return;
+
+    const overflow = lines.length - this.retention;
+    await fs.appendFile(`${this.logPath}.1`, `${lines.slice(0, overflow).join('\n')}\n`, 'utf-8');
+    await fs.writeFile(this.logPath, `${lines.slice(overflow).join('\n')}\n`, 'utf-8');
   }
 }

--- a/packages/code-notes-core/src/auditLog.ts
+++ b/packages/code-notes-core/src/auditLog.ts
@@ -1,0 +1,100 @@
+import * as fs from 'fs/promises';
+import { createHash } from 'crypto';
+import * as path from 'path';
+import type { LockManager } from './lockManager.js';
+import type { AuditEntry } from './types.js';
+
+/** Lock id for rotation. Not a note id — no note can collide with it. */
+const ROTATE_LOCK_ID = '_audit';
+
+/** sha256 of a note's content. Named to contrast with Note.contentHash (code hash). */
+export function hashNoteContent(content: string): string {
+  return `sha256:${createHash('sha256').update(content).digest('hex')}`;
+}
+
+/**
+ * Append-only JSONL log of agent operations.
+ *
+ * ponytail: appends are a bare fs.appendFile — one line, one O_APPEND write,
+ * which the OS keeps atomic for small writes on a local filesystem. That is
+ * why entries must stay short and single-line. Rotation is a read-modify-write
+ * and takes the lock; if this ever moves to a network filesystem, neither
+ * guarantee holds and this needs a real append service.
+ */
+export class AuditLog {
+  private retention: number;
+
+  constructor(
+    private logPath: string,
+    private opts: { lockManager?: LockManager; retention?: number } = {},
+  ) {
+    this.retention = opts.retention ?? 1000;
+  }
+
+  async append(entry: AuditEntry): Promise<void> {
+    await fs.mkdir(path.dirname(this.logPath), { recursive: true });
+    await fs.appendFile(this.logPath, `${JSON.stringify(entry)}\n`, 'utf-8');
+    await this.rotateIfNeeded();
+  }
+
+  /** Newest-first. Tolerant: unparseable lines are skipped, not fatal. */
+  async read(limit?: number): Promise<AuditEntry[]> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(this.logPath, 'utf-8');
+    } catch {
+      return [];
+    }
+
+    const entries: AuditEntry[] = [];
+    let skipped = 0;
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        entries.push(JSON.parse(line) as AuditEntry);
+      } catch {
+        skipped++;
+      }
+    }
+    if (skipped > 0) {
+      console.warn(`[code-notes-core] skipped ${skipped} unparseable audit log line(s)`);
+    }
+
+    entries.reverse();
+    return limit === undefined ? entries : entries.slice(0, limit);
+  }
+
+  async truncate(): Promise<void> {
+    await fs.writeFile(this.logPath, '', 'utf-8');
+  }
+
+  /**
+   * Rotation is read-modify-write: another process appending between our read
+   * and our rewrite would lose its line. Hold the lock across the whole thing
+   * and re-read inside it.
+   */
+  private async rotateIfNeeded(): Promise<void> {
+    const run = async () => {
+      let raw: string;
+      try {
+        raw = await fs.readFile(this.logPath, 'utf-8');
+      } catch {
+        return;
+      }
+      const lines = raw.split('\n').filter(l => l.trim());
+      if (lines.length <= this.retention) return;
+
+      const overflow = lines.length - this.retention;
+      await fs.appendFile(`${this.logPath}.1`, `${lines.slice(0, overflow).join('\n')}\n`, 'utf-8');
+      await fs.writeFile(this.logPath, `${lines.slice(overflow).join('\n')}\n`, 'utf-8');
+    };
+
+    try {
+      await (this.opts.lockManager ? this.opts.lockManager.withLock(ROTATE_LOCK_ID, run) : run());
+    } catch (e) {
+      // A missed rotation is a log that grows; a thrown error here would fail
+      // the agent's write. Losing the write is worse than a long log.
+      console.warn(`[code-notes-core] audit log rotation skipped: ${(e as Error).message}`);
+    }
+  }
+}

--- a/packages/code-notes-core/src/auditLog.ts
+++ b/packages/code-notes-core/src/auditLog.ts
@@ -33,47 +33,27 @@ export class AuditLog {
 
   async append(entry: AuditEntry): Promise<void> {
     await fs.mkdir(path.dirname(this.logPath), { recursive: true });
-    const line = `${JSON.stringify(entry)}\n`;
-    const lock = this.opts.lockManager;
-
-    // The append must share the rotation's critical section. A lock only
-    // orders writers that take it: a lock-free append landing between
-    // rotation's read and its truncating write is silently dropped.
-    let appended = false;
-    const writeThenRotate = async () => {
-      await fs.appendFile(this.logPath, line, 'utf-8');
-      appended = true;
-      try {
-        await this.rotate();
-      } catch (e) {
-        // A missed rotation is a log that grows; failing here would fail the
-        // agent's note write. A long log is the lesser evil.
-        console.warn(`[code-notes-core] audit log rotation skipped: ${(e as Error).message}`);
-      }
-    };
-
-    if (!lock) return writeThenRotate();
-
-    try {
-      await lock.withLock(ROTATE_LOCK_ID, writeThenRotate);
-    } catch (e) {
-      if (appended) throw e;
-      // Couldn't get the lock (or it broke). Never cost an agent its write
-      // over the audit lock: append lock-free. O_APPEND is atomic, so the
-      // line lands; only a rotation racing this exact moment could miss it.
-      console.warn(`[code-notes-core] audit append fell back to lock-free: ${(e as Error).message}`);
-      await fs.appendFile(this.logPath, line, 'utf-8');
-    }
+    // Lock-free by design. One line, one O_APPEND write, which the OS keeps
+    // atomic for small writes on a local filesystem — concurrent appenders
+    // never interleave, and rotation (below) never rewrites this file, so
+    // nothing can clobber the line either. An earlier version took the
+    // rotation lock here; under load the 500ms budget was exhausted on
+    // ~90% of appends, so it protected almost nothing while risking an
+    // agent's write on a busy lock.
+    await fs.appendFile(this.logPath, `${JSON.stringify(entry)}\n`, 'utf-8');
+    await this.rotateIfNeeded();
   }
 
   /** Newest-first. Tolerant: unparseable lines are skipped, not fatal. */
   async read(limit?: number): Promise<AuditEntry[]> {
-    let raw: string;
-    try {
-      raw = await fs.readFile(this.logPath, 'utf-8');
-    } catch {
-      return [];
-    }
+    // Span both generations, oldest first. Rotation renames the whole log, so
+    // immediately afterwards the live file is nearly empty and the recent
+    // history is in `.1` — reading only the live file would blank the Agent
+    // activity view at every rollover.
+    const rotated = await fs.readFile(`${this.logPath}.1`, 'utf-8').catch(() => '');
+    const live = await fs.readFile(this.logPath, 'utf-8').catch(() => '');
+    const raw = rotated + live;
+    if (!raw.trim()) return [];
 
     const entries: AuditEntry[] = [];
     let skipped = 0;
@@ -93,30 +73,52 @@ export class AuditLog {
     return limit === undefined ? entries : entries.slice(0, limit);
   }
 
+  /** Clears both generations — "clear the log" must not leave `.1` behind. */
   async truncate(): Promise<void> {
     await fs.writeFile(this.logPath, '', 'utf-8');
+    await fs.unlink(`${this.logPath}.1`).catch(() => undefined);
   }
 
   /**
-   * Trim the log to the retention cap, moving the overflow to `<log>.1`.
+   * Roll the log over to `<log>.1` once it exceeds the retention cap.
    *
-   * Read-modify-write, and deliberately NOT self-locking: append() calls this
-   * inside the lock it already holds, and LockManager is not reentrant —
-   * taking it again here would deadlock until lock_timeout. Never call this
-   * outside that critical section.
+   * The rename is the point: it's atomic, so an append racing it lands in
+   * whichever inode it opened — the rotated file or the fresh log — and is
+   * readable either way. The previous version read the log and wrote back a
+   * trimmed copy, which silently dropped any append that arrived in between.
+   *
+   * The lock only orders rotation against rotation (a second renamer could
+   * move a nearly-empty log over a full `.1`). It re-reads the count inside
+   * the lock, so a queued rotation sees the fresh log and stands down.
    */
-  private async rotate(): Promise<void> {
-    let raw: string;
-    try {
-      raw = await fs.readFile(this.logPath, 'utf-8');
-    } catch {
-      return;
-    }
-    const lines = raw.split('\n').filter(l => l.trim());
-    if (lines.length <= this.retention) return;
+  private async rotateIfNeeded(): Promise<void> {
+    // Unlocked pre-check. Almost no append rotates — taking the lock merely to
+    // read the count made every concurrent append queue on it and exhaust the
+    // retry budget, so the log spewed timeout warnings while doing nothing.
+    if (!(await this.exceedsRetention())) return;
 
-    const overflow = lines.length - this.retention;
-    await fs.appendFile(`${this.logPath}.1`, `${lines.slice(0, overflow).join('\n')}\n`, 'utf-8');
-    await fs.writeFile(this.logPath, `${lines.slice(overflow).join('\n')}\n`, 'utf-8');
+    const run = async () => {
+      // Re-check under the lock: a queued rotation would otherwise move an
+      // already-rotated, nearly-empty log over a full `.1`.
+      if (!(await this.exceedsRetention())) return;
+      await fs.rename(this.logPath, `${this.logPath}.1`);
+    };
+
+    try {
+      await (this.opts.lockManager ? this.opts.lockManager.withLock(ROTATE_LOCK_ID, run) : run());
+    } catch (e) {
+      // A skipped rotation is a log that grows past its cap; failing here
+      // would fail the agent's note write. A long log is the lesser evil.
+      console.warn(`[code-notes-core] audit log rotation skipped: ${(e as Error).message}`);
+    }
+  }
+
+  private async exceedsRetention(): Promise<boolean> {
+    try {
+      const raw = await fs.readFile(this.logPath, 'utf-8');
+      return raw.split('\n').filter(l => l.trim()).length > this.retention;
+    } catch {
+      return false;
+    }
   }
 }

--- a/packages/code-notes-core/src/index.ts
+++ b/packages/code-notes-core/src/index.ts
@@ -1,5 +1,7 @@
 export * from './types.js';
 export * from './noteDefaults.js';
+export * from './workspaceConfig.js';
+export * from './proposalStore.js';
 export * from './exportGenerator.js';
 export * from './lockManager.js';
 export * from './storageManager.js';

--- a/packages/code-notes-core/src/index.ts
+++ b/packages/code-notes-core/src/index.ts
@@ -2,6 +2,7 @@ export * from './types.js';
 export * from './noteDefaults.js';
 export * from './workspaceConfig.js';
 export * from './proposalStore.js';
+export * from './auditLog.js';
 export * from './exportGenerator.js';
 export * from './lockManager.js';
 export * from './storageManager.js';

--- a/packages/code-notes-core/src/noteManager.ts
+++ b/packages/code-notes-core/src/noteManager.ts
@@ -6,12 +6,13 @@
 import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { EventEmitter } from 'events';
-import { Note, CreateNoteParams, UpdateNoteParams, LineRange, NoteType, NotePriority, NoteScope, NoteReference, AuthorType, NoteDocument, AuthorProvider, SearchIndexSync, AgentWriteMode, AuditEntry } from './types.js';
+import { Note, CreateNoteParams, UpdateNoteParams, LineRange, NoteType, NotePriority, NoteScope, NoteReference, AuthorType, NoteDocument, AuthorProvider, SearchIndexSync, AgentWriteMode, AuditEntry, Proposal } from './types.js';
 import { applyDefaults } from './noteDefaults.js';
 import { StorageManager } from './storageManager.js';
 import { ContentHashTracker } from './contentHashTracker.js';
 import { LockManager } from './lockManager.js';
 import { AuditLog, hashNoteContent } from './auditLog.js';
+import { ProposalStore, PendingWriteError } from './proposalStore.js';
 
 /**
  * NoteManager coordinates all note operations
@@ -28,6 +29,7 @@ export class NoteManager extends EventEmitter {
   private defaultAuthor: string = 'Unknown User';
   private lockManager?: LockManager;
   private auditLog?: AuditLog;
+  private proposalStore?: ProposalStore;
   private agentWriteMode?: () => Promise<AgentWriteMode>;
   private agentName: string;
 
@@ -38,6 +40,7 @@ export class NoteManager extends EventEmitter {
     opts?: {
       lockManager?: LockManager;
       auditLog?: AuditLog;
+      proposalStore?: ProposalStore;
       /** A function, not a value: the mode is re-read per call so a
        *  long-lived process can't serve a stale policy. */
       agentWriteMode?: () => Promise<AgentWriteMode>;
@@ -51,6 +54,7 @@ export class NoteManager extends EventEmitter {
     this.noteCache = new Map();
     this.lockManager = opts?.lockManager;
     this.auditLog = opts?.auditLog;
+    this.proposalStore = opts?.proposalStore;
     this.agentWriteMode = opts?.agentWriteMode;
     this.agentName = opts?.agentName ?? 'unknown-agent';
 
@@ -76,6 +80,28 @@ export class NoteManager extends EventEmitter {
     const mode = await this.agentWriteMode();
     if (mode !== 'audit') return;
     await this.auditLog.append({ ...entry, ts: new Date().toISOString(), agent: this.agentName });
+  }
+
+  /**
+   * In queue mode an agent write becomes a proposal and never touches live
+   * notes. Throws PendingWriteError rather than returning a flag, so a caller
+   * cannot accidentally carry on and write anyway.
+   */
+  private async divertToProposalIfQueued(
+    isAgentWrite: boolean,
+    proposal: Omit<Proposal, 'proposalId' | 'agent' | 'proposedAt'>,
+  ): Promise<void> {
+    if (!isAgentWrite || !this.proposalStore || !this.agentWriteMode) return;
+    if (await this.agentWriteMode() !== 'queue') return;
+
+    const proposalId = `prop-${uuidv4()}`;
+    await this.proposalStore.save({
+      ...proposal,
+      proposalId,
+      agent: this.agentName,
+      proposedAt: new Date().toISOString(),
+    });
+    throw new PendingWriteError(proposalId);
   }
 
   /**
@@ -107,6 +133,15 @@ export class NoteManager extends EventEmitter {
     const noteId = uuidv4();
 
     return this.withNoteLock(noteId, async () => {
+      // Before any storage write: in queue mode this becomes a proposal and
+      // no note is created.
+      await this.divertToProposalIfQueued(params.authorType === 'agent', {
+        op: 'create',
+        file: params.filePath,
+        lineRange: params.lineRange,
+        content: params.content.trim(),
+      });
+
       // Generate content hash
       const contentHash = this.hashTracker.generateHash(document, params.lineRange);
 
@@ -196,6 +231,15 @@ export class NoteManager extends EventEmitter {
       }
 
       const prevContent = note.content;
+
+      await this.divertToProposalIfQueued(note.authorType === 'agent', {
+        op: 'edit',
+        targetNoteId: note.id,
+        file: note.filePath,
+        lineRange: note.lineRange,
+        content: params.content.trim(),
+        targetContentHash: hashNoteContent(prevContent),
+      });
 
       // Get author
       const author = params.author || await this.gitIntegration.getAuthorName();
@@ -298,6 +342,14 @@ export class NoteManager extends EventEmitter {
       if (note.isDeleted) {
         throw new Error(`Note ${noteId} is already deleted`);
       }
+
+      await this.divertToProposalIfQueued(note.authorType === 'agent', {
+        op: 'delete',
+        targetNoteId: note.id,
+        file: note.filePath,
+        content: '',
+        targetContentHash: hashNoteContent(note.content),
+      });
 
       // Mark as deleted
       note.isDeleted = true;

--- a/packages/code-notes-core/src/noteManager.ts
+++ b/packages/code-notes-core/src/noteManager.ts
@@ -106,6 +106,13 @@ export class NoteManager extends EventEmitter {
             action: 'created'
           }
         ],
+        ...(params.type !== undefined && { type: params.type }),
+        ...(params.tags !== undefined && { tags: params.tags }),
+        ...(params.scope !== undefined && { scope: params.scope }),
+        ...(params.references !== undefined && { references: params.references }),
+        ...(params.priority !== undefined && { priority: params.priority }),
+        ...(params.expiresAt !== undefined && { expiresAt: params.expiresAt }),
+        ...(params.authorType !== undefined && { authorType: params.authorType }),
         isDeleted: false
       };
 

--- a/packages/code-notes-core/src/noteManager.ts
+++ b/packages/code-notes-core/src/noteManager.ts
@@ -32,6 +32,7 @@ export class NoteManager extends EventEmitter {
   private proposalStore?: ProposalStore;
   private agentWriteMode?: () => Promise<AgentWriteMode>;
   private agentName: string;
+  private agentWriter: boolean;
 
   constructor(
     storage: StorageManager,
@@ -45,6 +46,17 @@ export class NoteManager extends EventEmitter {
        *  long-lived process can't serve a stale policy. */
       agentWriteMode?: () => Promise<AgentWriteMode>;
       agentName?: string;
+      /**
+       * True when this NoteManager belongs to an agent (the MCP server), so
+       * every write it makes is an agent write. One instance serves one
+       * identity — the extension's manager leaves this false.
+       *
+       * Identity has to come from the writer, not the note: keying off a
+       * note's authorType let an agent edit human-authored notes with no
+       * approval, and would have diverted a human's own revert of an agent
+       * note into a proposal.
+       */
+      agentWriter?: boolean;
     }
   ) {
     super();
@@ -57,6 +69,9 @@ export class NoteManager extends EventEmitter {
     this.proposalStore = opts?.proposalStore;
     this.agentWriteMode = opts?.agentWriteMode;
     this.agentName = opts?.agentName ?? 'unknown-agent';
+    // An instance wired for agent routing but not explicitly flagged is still
+    // an agent's — only the extension constructs a manager with neither.
+    this.agentWriter = opts?.agentWriter ?? !!(opts?.proposalStore || opts?.auditLog);
 
     // Initialize default author
     this.initializeDefaultAuthor();
@@ -135,7 +150,7 @@ export class NoteManager extends EventEmitter {
     return this.withNoteLock(noteId, async () => {
       // Before any storage write: in queue mode this becomes a proposal and
       // no note is created.
-      await this.divertToProposalIfQueued(params.authorType === 'agent', {
+      await this.divertToProposalIfQueued(this.agentWriter || params.authorType === 'agent', {
         op: 'create',
         file: params.filePath,
         lineRange: params.lineRange,
@@ -198,7 +213,7 @@ export class NoteManager extends EventEmitter {
       this.emit('noteCreated', normalized);
       this.emit('noteChanged', { type: 'created', note: normalized });
 
-      await this.recordAgentOp(params.authorType === 'agent', {
+      await this.recordAgentOp(this.agentWriter || params.authorType === 'agent', {
         op: 'create',
         noteId: normalized.id,
         file: normalized.filePath,
@@ -232,7 +247,7 @@ export class NoteManager extends EventEmitter {
 
       const prevContent = note.content;
 
-      await this.divertToProposalIfQueued(note.authorType === 'agent', {
+      await this.divertToProposalIfQueued(this.agentWriter, {
         op: 'edit',
         targetNoteId: note.id,
         file: note.filePath,
@@ -277,7 +292,7 @@ export class NoteManager extends EventEmitter {
       this.emit('noteUpdated', note);
       this.emit('noteChanged', { type: 'updated', note });
 
-      await this.recordAgentOp(note.authorType === 'agent', {
+      await this.recordAgentOp(this.agentWriter, {
         op: 'edit',
         noteId: note.id,
         file: note.filePath,
@@ -343,7 +358,7 @@ export class NoteManager extends EventEmitter {
         throw new Error(`Note ${noteId} is already deleted`);
       }
 
-      await this.divertToProposalIfQueued(note.authorType === 'agent', {
+      await this.divertToProposalIfQueued(this.agentWriter, {
         op: 'delete',
         targetNoteId: note.id,
         file: note.filePath,
@@ -381,7 +396,7 @@ export class NoteManager extends EventEmitter {
       this.emit('noteDeleted', { noteId, filePath });
       this.emit('noteChanged', { type: 'deleted', noteId, filePath });
 
-      await this.recordAgentOp(note.authorType === 'agent', {
+      await this.recordAgentOp(this.agentWriter, {
         op: 'delete',
         noteId: note.id,
         file: note.filePath,

--- a/packages/code-notes-core/src/noteManager.ts
+++ b/packages/code-notes-core/src/noteManager.ts
@@ -264,6 +264,9 @@ export class NoteManager extends EventEmitter {
       const now = new Date().toISOString();
       note.content = params.content.trim();
       note.author = author;
+      if (params.approvedBy !== undefined) {
+        note.approvedBy = params.approvedBy;
+      }
       note.updatedAt = now;
 
       // Add history entry
@@ -514,7 +517,7 @@ export class NoteManager extends EventEmitter {
         content: note.content,
         author: await this.gitIntegration.getAuthorName(),
         timestamp: note.updatedAt,
-        action: 'edited',
+        action: 'restored',
       });
 
       await this.storage.saveNote(note);

--- a/packages/code-notes-core/src/noteManager.ts
+++ b/packages/code-notes-core/src/noteManager.ts
@@ -6,11 +6,12 @@
 import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { EventEmitter } from 'events';
-import { Note, CreateNoteParams, UpdateNoteParams, LineRange, NoteType, NotePriority, NoteScope, NoteReference, AuthorType, NoteDocument, AuthorProvider, SearchIndexSync } from './types.js';
+import { Note, CreateNoteParams, UpdateNoteParams, LineRange, NoteType, NotePriority, NoteScope, NoteReference, AuthorType, NoteDocument, AuthorProvider, SearchIndexSync, AgentWriteMode, AuditEntry } from './types.js';
 import { applyDefaults } from './noteDefaults.js';
 import { StorageManager } from './storageManager.js';
 import { ContentHashTracker } from './contentHashTracker.js';
 import { LockManager } from './lockManager.js';
+import { AuditLog, hashNoteContent } from './auditLog.js';
 
 /**
  * NoteManager coordinates all note operations
@@ -26,12 +27,22 @@ export class NoteManager extends EventEmitter {
   private workspaceNotesByFileCache: Map<string, Note[]> | null = null; // cache for notes grouped by file
   private defaultAuthor: string = 'Unknown User';
   private lockManager?: LockManager;
+  private auditLog?: AuditLog;
+  private agentWriteMode?: () => Promise<AgentWriteMode>;
+  private agentName: string;
 
   constructor(
     storage: StorageManager,
     hashTracker: ContentHashTracker,
     gitIntegration: AuthorProvider,
-    opts?: { lockManager?: LockManager }
+    opts?: {
+      lockManager?: LockManager;
+      auditLog?: AuditLog;
+      /** A function, not a value: the mode is re-read per call so a
+       *  long-lived process can't serve a stale policy. */
+      agentWriteMode?: () => Promise<AgentWriteMode>;
+      agentName?: string;
+    }
   ) {
     super();
     this.storage = storage;
@@ -39,6 +50,9 @@ export class NoteManager extends EventEmitter {
     this.gitIntegration = gitIntegration;
     this.noteCache = new Map();
     this.lockManager = opts?.lockManager;
+    this.auditLog = opts?.auditLog;
+    this.agentWriteMode = opts?.agentWriteMode;
+    this.agentName = opts?.agentName ?? 'unknown-agent';
 
     // Initialize default author
     this.initializeDefaultAuthor();
@@ -50,6 +64,18 @@ export class NoteManager extends EventEmitter {
    */
   private withNoteLock<T>(noteId: string, fn: () => Promise<T>): Promise<T> {
     return this.lockManager ? this.lockManager.withLock(noteId, fn) : fn();
+  }
+
+  /**
+   * Record an agent op if the workspace is in audit mode. Human writes are
+   * never logged — detection is `authorType: 'agent'`, never author-string
+   * sniffing.
+   */
+  private async recordAgentOp(isAgentWrite: boolean, entry: Omit<AuditEntry, 'ts' | 'agent'>): Promise<void> {
+    if (!isAgentWrite || !this.auditLog || !this.agentWriteMode) return;
+    const mode = await this.agentWriteMode();
+    if (mode !== 'audit') return;
+    await this.auditLog.append({ ...entry, ts: new Date().toISOString(), agent: this.agentName });
   }
 
   /**
@@ -137,6 +163,14 @@ export class NoteManager extends EventEmitter {
       this.emit('noteCreated', normalized);
       this.emit('noteChanged', { type: 'created', note: normalized });
 
+      await this.recordAgentOp(params.authorType === 'agent', {
+        op: 'create',
+        noteId: normalized.id,
+        file: normalized.filePath,
+        lineRange: [normalized.lineRange.start, normalized.lineRange.end],
+        type: normalized.type,
+      });
+
       return normalized;
     });
   }
@@ -160,6 +194,8 @@ export class NoteManager extends EventEmitter {
       if (note.isDeleted) {
         throw new Error(`Cannot update deleted note ${params.id}`);
       }
+
+      const prevContent = note.content;
 
       // Get author
       const author = params.author || await this.gitIntegration.getAuthorName();
@@ -196,6 +232,14 @@ export class NoteManager extends EventEmitter {
       this.clearWorkspaceCache();
       this.emit('noteUpdated', note);
       this.emit('noteChanged', { type: 'updated', note });
+
+      await this.recordAgentOp(note.authorType === 'agent', {
+        op: 'edit',
+        noteId: note.id,
+        file: note.filePath,
+        prevContentHash: hashNoteContent(prevContent),
+        newContentHash: hashNoteContent(note.content),
+      });
 
       return note;
     });
@@ -284,6 +328,12 @@ export class NoteManager extends EventEmitter {
       this.clearWorkspaceCache();
       this.emit('noteDeleted', { noteId, filePath });
       this.emit('noteChanged', { type: 'deleted', noteId, filePath });
+
+      await this.recordAgentOp(note.authorType === 'agent', {
+        op: 'delete',
+        noteId: note.id,
+        file: note.filePath,
+      });
     });
   }
 

--- a/packages/code-notes-core/src/noteManager.ts
+++ b/packages/code-notes-core/src/noteManager.ts
@@ -312,6 +312,15 @@ export class NoteManager extends EventEmitter {
     noteId: string,
     fields: { type?: NoteType; priority?: NotePriority; tags?: string[]; expiresAt?: string; scope?: NoteScope; references?: NoteReference[]; authorType?: AuthorType },
   ): Promise<Note> {
+    // Human-only path: this writes notes but is NOT routed through the trust
+    // model, and it is safe today only because no MCP tool reaches it. Fail
+    // loudly rather than let a future agent-facing caller silently bypass the
+    // rails — that class of mistake is exactly how agents got to edit
+    // human-authored notes in queue mode.
+    if (this.agentWriter) {
+      throw new Error('updateNoteMetadata is not available to agent writers — route the change through updateNote');
+    }
+
     return this.withNoteLock(noteId, async () => {
       const existing = await this.storage.loadNoteById(noteId);
       if (!existing) throw new Error(`Note ${noteId} not found`);
@@ -471,6 +480,12 @@ export class NoteManager extends EventEmitter {
    * Returns notes that were updated
    */
   async updateNotePositions(document: NoteDocument): Promise<Note[]> {
+    // Human-only path, like updateNoteMetadata: repositioning follows the
+    // editor's document changes and is not routed through the trust model.
+    if (this.agentWriter) {
+      throw new Error('updateNotePositions is not available to agent writers');
+    }
+
     const filePath = document.uri.fsPath;
     const notes = await this.getNotesForFile(filePath);
     const updatedNotes: Note[] = [];

--- a/packages/code-notes-core/src/noteManager.ts
+++ b/packages/code-notes-core/src/noteManager.ts
@@ -460,37 +460,44 @@ export class NoteManager extends EventEmitter {
     const notes = await this.getNotesForFile(filePath);
     const updatedNotes: Note[] = [];
 
-    for (const note of notes) {
-      // Check if content is still at the expected location
+    for (const cached of notes) {
+      // Deciding *whether* a note moved is a pure read of the document, so the
+      // cached copy is fine for it — and it keeps the common case (nothing
+      // moved) lock-free.
       const isValid = this.hashTracker.validateContentHash(
         document,
-        note.lineRange,
-        note.contentHash
+        cached.lineRange,
+        cached.contentHash
       );
+      if (isValid) continue;
 
-      if (!isValid) {
-        // Try to find the content at a new location
-        const result = await this.hashTracker.findContentByHash(
-          document,
-          note.contentHash,
-          note.lineRange
-        );
+      const result = await this.hashTracker.findContentByHash(
+        document,
+        cached.contentHash,
+        cached.lineRange
+      );
+      if (!result.found || !result.newLineRange) continue;
 
-        if (result.found && result.newLineRange) {
-          // Update note position
-          note.lineRange = result.newLineRange;
-          note.updatedAt = new Date().toISOString();
+      const newLineRange = result.newLineRange;
+      await this.withNoteLock(cached.id, async () => {
+        // Re-read inside the lock before writing: another process may have
+        // edited this note's content since our cache warmed, and saving the
+        // cached object would erase that edit (the v0.4 lost-update bug).
+        const raw = await this.storage.loadNoteById(cached.id);
+        if (!raw) return;
+        const note = applyDefaults(raw);
+        if (note.isDeleted) return;
 
-          // Save updated note
-          await this.storage.saveNote(note);
-          updatedNotes.push(note);
-        }
-      }
+        note.lineRange = newLineRange;
+        note.updatedAt = new Date().toISOString();
+        await this.storage.saveNote(note);
+        this.updateNoteInCache(note);
+        updatedNotes.push(note);
+      });
     }
 
-    // Update cache
     if (updatedNotes.length > 0) {
-      this.noteCache.set(filePath, notes);
+      this.clearWorkspaceCache();
     }
 
     return updatedNotes;

--- a/packages/code-notes-core/src/noteManager.ts
+++ b/packages/code-notes-core/src/noteManager.ts
@@ -189,6 +189,7 @@ export class NoteManager extends EventEmitter {
         ...(params.priority !== undefined && { priority: params.priority }),
         ...(params.expiresAt !== undefined && { expiresAt: params.expiresAt }),
         ...(params.authorType !== undefined && { authorType: params.authorType }),
+        ...(params.approvedBy !== undefined && { approvedBy: params.approvedBy }),
         isDeleted: false
       };
 
@@ -572,6 +573,11 @@ export class NoteManager extends EventEmitter {
         notes[index] = applyDefaults(updatedNote);
       }
     }
+  }
+
+  /** The human's display name — used to attribute an approved proposal. */
+  async getDefaultAuthor(): Promise<string> {
+    return this.gitIntegration.getAuthorName();
   }
 
   /**

--- a/packages/code-notes-core/src/noteManager.ts
+++ b/packages/code-notes-core/src/noteManager.ts
@@ -477,6 +477,59 @@ export class NoteManager extends EventEmitter {
   }
 
   /**
+   * Like getNoteByIdGlobal but returns soft-deleted notes too. The audit-mode
+   * Revert of a delete needs to see the deleted note to restore it, and Open
+   * needs to jump to a deleted note's location.
+   */
+  async getNoteByIdIncludingDeleted(noteId: string): Promise<Note | undefined> {
+    const note = await this.storage.loadNoteById(noteId);
+    return note ? applyDefaults(note) : undefined;
+  }
+
+  /**
+   * Restore a soft-deleted note — the reverse of deleteNote, used by Revert.
+   * The note's content survived the delete, so this clears isDeleted and
+   * records the restore in history. Human-only, like the other unrouted write
+   * paths: fail closed for agent writers rather than let a future agent tool
+   * bypass the trust model.
+   */
+  async undeleteNote(noteId: string): Promise<Note> {
+    if (this.agentWriter) {
+      throw new Error('undeleteNote is not available to agent writers');
+    }
+    return this.withNoteLock(noteId, async () => {
+      // Fresh read inside the lock — see updateNote.
+      const raw = await this.storage.loadNoteById(noteId);
+      const note = raw ? applyDefaults(raw) : undefined;
+      if (!note) {
+        throw new Error(`Note with id ${noteId} not found`);
+      }
+      if (!note.isDeleted) {
+        throw new Error(`Note ${noteId} is not deleted`);
+      }
+
+      note.isDeleted = false;
+      note.updatedAt = new Date().toISOString();
+      note.history.push({
+        content: note.content,
+        author: await this.gitIntegration.getAuthorName(),
+        timestamp: note.updatedAt,
+        action: 'edited',
+      });
+
+      await this.storage.saveNote(note);
+      this.updateNoteInCache(note);
+      if (this.searchManager) {
+        await this.searchManager.updateIndex(note);
+      }
+      this.clearWorkspaceCache();
+      this.emit('noteUpdated', note);
+      this.emit('noteChanged', { type: 'updated', note });
+      return note;
+    });
+  }
+
+  /**
    * Update note positions when document changes
    * Returns notes that were updated
    */

--- a/packages/code-notes-core/src/proposalStore.ts
+++ b/packages/code-notes-core/src/proposalStore.ts
@@ -17,6 +17,23 @@ export class PendingWriteError extends Error {
 const REJECTED_DIR = '.rejected';
 
 /**
+ * Read a scalar written by save(): JSON-encoded free-text fields decode back to
+ * their raw value. Tolerant of a bare (non-JSON) value so a hand-edited or
+ * pre-hardening file still loads.
+ */
+function decodeScalar(value: string | undefined, fallback: string): string {
+  if (value === undefined) return fallback;
+  if (value.startsWith('"')) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+  return value;
+}
+
+/**
  * ponytail: proposals are markdown-with-frontmatter, hand-serialized like
  * notes are, rather than pulling in a YAML dependency for six scalar fields.
  * If the shape grows past scalars + one body, switch to the same serializer
@@ -31,14 +48,18 @@ export class ProposalStore {
 
   async save(p: Proposal): Promise<void> {
     await fs.mkdir(this.pendingDir, { recursive: true });
+    // JSON-encode the free-text scalars (file, agent). These are the only
+    // frontmatter values an agent influences, and a raw newline in one would
+    // introduce a premature `---` that splits the frontmatter and hijacks the
+    // fields/content below it. JSON.stringify makes them single-line.
     const lines = [
       '---',
       `proposalId: ${p.proposalId}`,
       `op: ${p.op}`,
       ...(p.targetNoteId ? [`targetNoteId: ${p.targetNoteId}`] : []),
-      `file: ${p.file}`,
+      `file: ${JSON.stringify(p.file)}`,
       ...(p.lineRange ? [`lineRange: [${p.lineRange.start}, ${p.lineRange.end}]`] : []),
-      `agent: ${p.agent}`,
+      `agent: ${JSON.stringify(p.agent)}`,
       `proposedAt: ${p.proposedAt}`,
       ...(p.targetContentHash ? [`targetContentHash: ${p.targetContentHash}`] : []),
       '---',
@@ -108,9 +129,9 @@ export class ProposalStore {
       proposalId: fields.proposalId,
       op: fields.op as Proposal['op'],
       ...(fields.targetNoteId && { targetNoteId: fields.targetNoteId }),
-      file: fields.file ?? '',
+      file: decodeScalar(fields.file, ''),
       ...(range && { lineRange: { start: Number(range[1]), end: Number(range[2]) } }),
-      agent: fields.agent ?? 'unknown-agent',
+      agent: decodeScalar(fields.agent, 'unknown-agent'),
       proposedAt: fields.proposedAt ?? '',
       ...(fields.targetContentHash && { targetContentHash: fields.targetContentHash }),
       content: match[2].replace(/\n$/, ''),

--- a/packages/code-notes-core/src/proposalStore.ts
+++ b/packages/code-notes-core/src/proposalStore.ts
@@ -1,0 +1,119 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import type { Proposal } from './types.js';
+
+/**
+ * Thrown by NoteManager when queue mode diverts an agent write. Not an
+ * error condition for the human — it is the expected outcome in queue mode,
+ * and the MCP layer turns it into a `{ status: 'pending' }` result.
+ */
+export class PendingWriteError extends Error {
+  constructor(readonly proposalId: string) {
+    super(`pending_approval: ${proposalId}`);
+    this.name = 'PendingWriteError';
+  }
+}
+
+const REJECTED_DIR = '.rejected';
+
+/**
+ * ponytail: proposals are markdown-with-frontmatter, hand-serialized like
+ * notes are, rather than pulling in a YAML dependency for six scalar fields.
+ * If the shape grows past scalars + one body, switch to the same serializer
+ * StorageManager uses.
+ */
+export class ProposalStore {
+  constructor(private pendingDir: string) {}
+
+  private filePath(proposalId: string): string {
+    return path.join(this.pendingDir, `${proposalId}.md`);
+  }
+
+  async save(p: Proposal): Promise<void> {
+    await fs.mkdir(this.pendingDir, { recursive: true });
+    const lines = [
+      '---',
+      `proposalId: ${p.proposalId}`,
+      `op: ${p.op}`,
+      ...(p.targetNoteId ? [`targetNoteId: ${p.targetNoteId}`] : []),
+      `file: ${p.file}`,
+      ...(p.lineRange ? [`lineRange: [${p.lineRange.start}, ${p.lineRange.end}]`] : []),
+      `agent: ${p.agent}`,
+      `proposedAt: ${p.proposedAt}`,
+      ...(p.targetContentHash ? [`targetContentHash: ${p.targetContentHash}`] : []),
+      '---',
+      p.content,
+    ];
+    await fs.writeFile(this.filePath(p.proposalId), `${lines.join('\n')}\n`, 'utf-8');
+  }
+
+  async load(proposalId: string): Promise<Proposal | null> {
+    try {
+      return this.parse(await fs.readFile(this.filePath(proposalId), 'utf-8'));
+    } catch {
+      return null;
+    }
+  }
+
+  /** Oldest-first: the review queue reads like a queue. */
+  async list(): Promise<Proposal[]> {
+    let files: string[];
+    try {
+      // Non-recursive, and the .md filter is what drops the `.rejected`
+      // directory entry — that is the only thing keeping rejected proposals
+      // out of the live queue. Make this recursive and every rejection
+      // silently comes back.
+      files = (await fs.readdir(this.pendingDir)).filter(f => f.endsWith('.md'));
+    } catch {
+      return [];
+    }
+
+    const proposals: Proposal[] = [];
+    for (const f of files) {
+      try {
+        const parsed = this.parse(await fs.readFile(path.join(this.pendingDir, f), 'utf-8'));
+        if (parsed) proposals.push(parsed);
+      } catch {
+        // One bad file must not hide the rest of the queue.
+      }
+    }
+    proposals.sort((a, b) => a.proposedAt.localeCompare(b.proposedAt));
+    return proposals;
+  }
+
+  /** Keep rejected proposals for audit rather than deleting them. */
+  async reject(proposalId: string): Promise<void> {
+    const rejectedDir = path.join(this.pendingDir, REJECTED_DIR);
+    await fs.mkdir(rejectedDir, { recursive: true });
+    await fs.rename(this.filePath(proposalId), path.join(rejectedDir, `${proposalId}.md`));
+  }
+
+  async remove(proposalId: string): Promise<void> {
+    await fs.unlink(this.filePath(proposalId)).catch(() => undefined);
+  }
+
+  private parse(raw: string): Proposal | null {
+    const match = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/.exec(raw);
+    if (!match) return null;
+
+    const fields: Record<string, string> = {};
+    for (const line of match[1].split('\n')) {
+      const idx = line.indexOf(': ');
+      if (idx > 0) fields[line.slice(0, idx)] = line.slice(idx + 2).trim();
+    }
+    if (!fields.proposalId || !fields.op) return null;
+
+    const range = /\[(\d+),\s*(\d+)\]/.exec(fields.lineRange ?? '');
+    return {
+      proposalId: fields.proposalId,
+      op: fields.op as Proposal['op'],
+      ...(fields.targetNoteId && { targetNoteId: fields.targetNoteId }),
+      file: fields.file ?? '',
+      ...(range && { lineRange: { start: Number(range[1]), end: Number(range[2]) } }),
+      agent: fields.agent ?? 'unknown-agent',
+      proposedAt: fields.proposedAt ?? '',
+      ...(fields.targetContentHash && { targetContentHash: fields.targetContentHash }),
+      content: match[2].replace(/\n$/, ''),
+    };
+  }
+}

--- a/packages/code-notes-core/src/storageManager.ts
+++ b/packages/code-notes-core/src/storageManager.ts
@@ -242,6 +242,11 @@ export class StorageManager implements NoteStorage {
 
     // Metadata
     lines.push(`## Note: ${note.id}`);
+    // Format discriminator. v2 length-delimits the content and history-entry
+    // regions so agent-controlled text can never reproduce a structural
+    // delimiter and be re-parsed as one. A note without this marker is read
+    // by the untouched v1 parser.
+    lines.push(`**Format:** 2`);
     lines.push(`**Author:** ${note.author}`);
     lines.push(`**Created:** ${note.createdAt}`);
     lines.push(`**Updated:** ${note.updatedAt}`);
@@ -275,6 +280,9 @@ export class StorageManager implements NoteStorage {
     if (note.isDeleted) {
       lines.push(`**Status:** DELETED`);
     }
+    // The parser reads exactly this many lines as content, so a "## Edit
+    // History" (or any delimiter) inside the content is just content.
+    lines.push(`**Content Lines:** ${note.content.split('\n').length}`);
     lines.push('');
 
     // Current content
@@ -293,7 +301,9 @@ export class StorageManager implements NoteStorage {
         lines.push(`### ${entry.timestamp} - ${entry.author} - ${entry.action}`);
         lines.push('');
         if (entry.content) {
-          lines.push('```');
+          // The count on the fence makes the entry length-delimited too, so a
+          // ``` inside an edit's body can't break out and forge a later entry.
+          lines.push('```lines=' + entry.content.split('\n').length);
           lines.push(entry.content);
           lines.push('```');
         }
@@ -309,191 +319,180 @@ export class StorageManager implements NoteStorage {
    */
   private markdownToNote(markdown: string): Note | null {
     const lines = markdown.split('\n');
-    const note: Partial<Note> = {
-      history: []
-    };
+    // Detect the format before the content section: a v1 note's content lives
+    // after '## Current Content', so a content line can never masquerade as
+    // the marker. Absent the marker, the untouched v1 parser handles it.
+    let isV2 = false;
+    for (const line of lines) {
+      if (line === '## Current Content') break;
+      if (line === '**Format:** 2') { isV2 = true; break; }
+    }
+    return isV2 ? this.parseNoteV2(lines) : this.parseNoteV1(lines);
+  }
 
+  /** Best-effort parse of one header/metadata line. Shared by both format
+   *  parsers; unrecognized lines are ignored. Never handles content or
+   *  history — those regions are the parsers' own concern. */
+  private applyMetadataLine(note: Partial<Note>, line: string): void {
+    if (line.startsWith('**File:**')) {
+      note.filePath = line.substring(9).trim();
+    } else if (line.startsWith('**Lines:**')) {
+      const range = line.substring(10).trim().split('-');
+      note.lineRange = { start: parseInt(range[0]) - 1, end: parseInt(range[1]) - 1 };
+    } else if (line.startsWith('**Content Hash:**') && !note.contentHash) {
+      note.contentHash = line.substring(17).trim();
+    } else if (line.startsWith('## Note: ')) {
+      note.id = line.substring(9).trim();
+    } else if (line.startsWith('**Author:**')) {
+      note.author = line.substring(11).trim();
+    } else if (line.startsWith('**Created:**')) {
+      note.createdAt = line.substring(12).trim();
+    } else if (line.startsWith('**Updated:**')) {
+      note.updatedAt = line.substring(12).trim();
+    } else if (line.startsWith('**Status:** DELETED')) {
+      note.isDeleted = true;
+    } else if (line.startsWith('**Type:**')) {
+      const v = line.substring(9).trim();
+      if ((VALID_TYPES as string[]).includes(v)) note.type = v as NoteType;
+      else console.warn(`[code-notes] Ignoring invalid Type for note: ${v}`);
+    } else if (line.startsWith('**Scope:**')) {
+      const v = line.substring(10).trim();
+      if ((VALID_SCOPES as string[]).includes(v)) note.scope = v as NoteScope;
+      else console.warn(`[code-notes] Ignoring invalid Scope for note: ${v}`);
+    } else if (line.startsWith('**Priority:**')) {
+      const v = line.substring(13).trim();
+      if ((VALID_PRIORITIES as string[]).includes(v)) note.priority = v as NotePriority;
+      else console.warn(`[code-notes] Ignoring invalid Priority for note: ${v}`);
+    } else if (line.startsWith('**Tags:**')) {
+      const raw = line.substring(9).trim();
+      note.tags = raw ? raw.split(',').map(t => t.trim()).filter(t => t.length > 0) : [];
+    } else if (line.startsWith('**ApprovedBy:**')) {
+      note.approvedBy = line.substring(15).trim();
+    } else if (line.startsWith('**AuthorType:**')) {
+      const v = line.substring(15).trim();
+      if ((VALID_AUTHOR_TYPES as string[]).includes(v)) note.authorType = v as AuthorType;
+      else console.warn(`[code-notes] Ignoring invalid AuthorType for note: ${v}`);
+    } else if (line.startsWith('**ExpiresAt:**')) {
+      note.expiresAt = line.substring(14).trim();
+    } else if (line.startsWith('**References:**')) {
+      const raw = line.substring(15).trim();
+      if (raw) {
+        try {
+          const parsed = JSON.parse(raw);
+          note.references = Array.isArray(parsed)
+            ? parsed.filter((r: unknown): r is NoteReference =>
+                !!r && typeof r === 'object' &&
+                typeof (r as NoteReference).value === 'string' &&
+                VALID_REFERENCE_KINDS.includes((r as NoteReference).kind))
+            : [];
+        } catch {
+          console.warn(`[code-notes] Failed to parse References for note: ${raw}`);
+          note.references = [];
+        }
+      }
+    }
+  }
+
+  private finalizeNote(note: Partial<Note>): Note | null {
+    if (note.isDeleted === undefined) note.isDeleted = false;
+    return this.isValidNote(note) ? (note as Note) : null;
+  }
+
+  /**
+   * Legacy parser for notes written before the v2 length-delimited format.
+   * Delimiter-based, and kept intact for back-compat — do not extend it; new
+   * fields belong in the v2 path. Its content/history regions are spoofable by
+   * content that reproduces a delimiter, which is exactly why v2 exists; v1 is
+   * only ever produced by pre-v0.5 code, and any note re-saved migrates to v2.
+   */
+  private parseNoteV1(lines: string[]): Note | null {
+    const note: Partial<Note> = { history: [] };
     let inContent = false;
     let inHistory = false;
     let contentLines: string[] = [];
     let historyContentLines: string[] = [];
     let currentHistoryEntry: any = null;
 
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
-
-      // Inside the content region every line is content, full stop. Note
-      // content is agent-controlled input, and the metadata branches below
-      // match on prefix — so without this, an agent could write a note whose
-      // body is "**Status:** DELETED" and have it parsed back as metadata:
-      // the note deletes itself on reload while the audit log records an
-      // ordinary edit. Same trick forged **Author:**/**AuthorType:**.
-      // The region ends only at its real terminator.
+    for (const line of lines) {
       if (inContent) {
-        if (line === '## Edit History') {
-          inContent = false;
-          inHistory = true;
-        } else {
-          contentLines.push(line);
-        }
+        if (line === '## Edit History') { inContent = false; inHistory = true; }
+        else contentLines.push(line);
         continue;
       }
-
-      // Same for the history region, which echoes every past version of the
-      // content — so the identical injection arrives here too, one edit later.
-      // Nothing follows Edit History in the format, so everything from here is
-      // history: an entry header, or an entry's body.
       if (inHistory) {
         if (line.startsWith('### ')) {
-          // Close the previous entry before starting the next.
           if (currentHistoryEntry && historyContentLines.length > 0) {
             currentHistoryEntry.content = historyContentLines.join('\n').trim();
           }
           const match = line.substring(4).match(/^(.+?) - (.+?) - (.+)$/);
           if (match) {
-            currentHistoryEntry = {
-              timestamp: match[1],
-              author: match[2],
-              action: match[3] as any,
-              content: ''
-            };
+            currentHistoryEntry = { timestamp: match[1], author: match[2], action: match[3] as any, content: '' };
             note.history!.push(currentHistoryEntry);
             historyContentLines = [];
           }
         } else if (currentHistoryEntry && line !== '```') {
-          if (line || historyContentLines.length > 0) {
-            historyContentLines.push(line);
-          }
+          if (line || historyContentLines.length > 0) historyContentLines.push(line);
         }
         continue;
       }
-
-      // Parse file path
-      if (line.startsWith('**File:**')) {
-        note.filePath = line.substring(9).trim();
-      }
-      // Parse line range
-      else if (line.startsWith('**Lines:**')) {
-        const range = line.substring(10).trim().split('-');
-        note.lineRange = {
-          start: parseInt(range[0]) - 1,
-          end: parseInt(range[1]) - 1
-        };
-      }
-      // Parse content hash (at top level)
-      else if (line.startsWith('**Content Hash:**') && !note.contentHash) {
-        note.contentHash = line.substring(17).trim();
-      }
-      // Parse note ID
-      else if (line.startsWith('## Note: ')) {
-        note.id = line.substring(9).trim();
-      }
-      // Parse metadata
-      else if (line.startsWith('**Author:**')) {
-        note.author = line.substring(11).trim();
-      }
-      else if (line.startsWith('**Created:**')) {
-        note.createdAt = line.substring(12).trim();
-      }
-      else if (line.startsWith('**Updated:**')) {
-        note.updatedAt = line.substring(12).trim();
-      }
-      else if (line.startsWith('**Status:** DELETED')) {
-        note.isDeleted = true;
-      }
-      // Parse new structured fields — invalid values are dropped (the note
-      // then gets the schema default at the NoteManager boundary)
-      else if (line.startsWith('**Type:**')) {
-        const v = line.substring(9).trim();
-        if ((VALID_TYPES as string[]).includes(v)) {
-          note.type = v as NoteType;
-        } else {
-          console.warn(`[code-notes] Ignoring invalid Type for note: ${v}`);
-        }
-      }
-      else if (line.startsWith('**Scope:**')) {
-        const v = line.substring(10).trim();
-        if ((VALID_SCOPES as string[]).includes(v)) {
-          note.scope = v as NoteScope;
-        } else {
-          console.warn(`[code-notes] Ignoring invalid Scope for note: ${v}`);
-        }
-      }
-      else if (line.startsWith('**Priority:**')) {
-        const v = line.substring(13).trim();
-        if ((VALID_PRIORITIES as string[]).includes(v)) {
-          note.priority = v as NotePriority;
-        } else {
-          console.warn(`[code-notes] Ignoring invalid Priority for note: ${v}`);
-        }
-      }
-      else if (line.startsWith('**Tags:**')) {
-        const raw = line.substring(9).trim();
-        note.tags = raw ? raw.split(',').map(t => t.trim()).filter(t => t.length > 0) : [];
-      }
-      else if (line.startsWith('**ApprovedBy:**')) {
-        note.approvedBy = line.substring(15).trim();
-      }
-      else if (line.startsWith('**AuthorType:**')) {
-        const v = line.substring(15).trim();
-        if ((VALID_AUTHOR_TYPES as string[]).includes(v)) {
-          note.authorType = v as AuthorType;
-        } else {
-          console.warn(`[code-notes] Ignoring invalid AuthorType for note: ${v}`);
-        }
-      }
-      else if (line.startsWith('**ExpiresAt:**')) {
-        note.expiresAt = line.substring(14).trim();
-      }
-      else if (line.startsWith('**References:**')) {
-        const raw = line.substring(15).trim();
-        if (raw) {
-          try {
-            const parsed = JSON.parse(raw);
-            // Salvage valid entries; drop malformed ones
-            note.references = Array.isArray(parsed)
-              ? parsed.filter(
-                  (r: unknown): r is NoteReference =>
-                    !!r && typeof r === 'object' &&
-                    typeof (r as NoteReference).value === 'string' &&
-                    VALID_REFERENCE_KINDS.includes((r as NoteReference).kind)
-                )
-              : [];
-          } catch {
-            console.warn(`[code-notes] Failed to parse References for note: ${raw}`);
-            note.references = [];
-          }
-        }
-      }
-      // Parse current content section
-      else if (line === '## Current Content') {
-        inContent = true;
-        inHistory = false;
-        contentLines = [];
-      }
-      // Parse history section
-      else if (line === '## Edit History') {
-        inContent = false;
-        inHistory = true;
-      }
+      if (line === '## Current Content') { inContent = true; inHistory = false; contentLines = []; continue; }
+      if (line === '## Edit History') { inContent = false; inHistory = true; continue; }
+      this.applyMetadataLine(note, line);
     }
 
-    // Save last history entry content
     if (currentHistoryEntry && historyContentLines.length > 0) {
       currentHistoryEntry.content = historyContentLines.join('\n').trim();
     }
+    if (contentLines.length > 0) note.content = contentLines.join('\n').trim();
+    return this.finalizeNote(note);
+  }
 
-    // Set final content
-    if (contentLines.length > 0) {
-      note.content = contentLines.join('\n').trim();
+  /**
+   * v2 parser. Content and every history entry are length-delimited: the
+   * parser reads exactly the declared number of lines, so agent-controlled
+   * text can contain any delimiter and is still captured verbatim.
+   */
+  private parseNoteV2(lines: string[]): Note | null {
+    const note: Partial<Note> = { history: [] };
+    let contentLineCount = 0;
+    let i = 0;
+
+    for (; i < lines.length; i++) {
+      const line = lines[i];
+      if (line === '## Current Content') break;
+      if (line === '**Format:** 2') continue;
+      if (line.startsWith('**Content Lines:**')) {
+        contentLineCount = parseInt(line.substring(18).trim(), 10) || 0;
+        continue;
+      }
+      this.applyMetadataLine(note, line);
     }
 
-    // Set default for isDeleted if not specified
-    if (note.isDeleted === undefined) {
-      note.isDeleted = false;
+    // '## Current Content', then one blank separator, then exactly N lines.
+    i += 2;
+    note.content = lines.slice(i, i + contentLineCount).join('\n');
+    i += contentLineCount;
+
+    while (i < lines.length && lines[i] !== '## Edit History') i++;
+    i++;
+    while (i < lines.length) {
+      const header = lines[i].startsWith('### ')
+        ? lines[i].substring(4).match(/^(.+?) - (.+?) - (.+)$/)
+        : null;
+      if (!header) { i++; continue; }
+      const entry: any = { timestamp: header[1], author: header[2], action: header[3] as any, content: '' };
+      note.history!.push(entry);
+      i++;
+      while (i < lines.length && !lines[i].startsWith('```lines=') && !lines[i].startsWith('### ')) i++;
+      const fence = i < lines.length ? lines[i].match(/^```lines=(\d+)$/) : null;
+      if (fence) {
+        const m = parseInt(fence[1], 10) || 0;
+        entry.content = lines.slice(i + 1, i + 1 + m).join('\n');
+        i += m + 2; // opener + m content lines + closing ```
+      }
     }
 
-    return this.isValidNote(note) ? (note as Note) : null;
+    return this.finalizeNote(note);
   }
 
   /**

--- a/packages/code-notes-core/src/storageManager.ts
+++ b/packages/code-notes-core/src/storageManager.ts
@@ -262,6 +262,9 @@ export class StorageManager implements NoteStorage {
     if (note.authorType && note.authorType !== NOTE_DEFAULTS.authorType) {
       lines.push(`**AuthorType:** ${note.authorType}`);
     }
+    if (note.approvedBy) {
+      lines.push(`**ApprovedBy:** ${note.approvedBy}`);
+    }
     if (note.expiresAt) {
       lines.push(`**ExpiresAt:** ${note.expiresAt}`);
     }
@@ -427,6 +430,9 @@ export class StorageManager implements NoteStorage {
       else if (line.startsWith('**Tags:**')) {
         const raw = line.substring(9).trim();
         note.tags = raw ? raw.split(',').map(t => t.trim()).filter(t => t.length > 0) : [];
+      }
+      else if (line.startsWith('**ApprovedBy:**')) {
+        note.approvedBy = line.substring(15).trim();
       }
       else if (line.startsWith('**AuthorType:**')) {
         const v = line.substring(15).trim();

--- a/packages/code-notes-core/src/storageManager.ts
+++ b/packages/code-notes-core/src/storageManager.ts
@@ -319,6 +319,52 @@ export class StorageManager implements NoteStorage {
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
 
+      // Inside the content region every line is content, full stop. Note
+      // content is agent-controlled input, and the metadata branches below
+      // match on prefix — so without this, an agent could write a note whose
+      // body is "**Status:** DELETED" and have it parsed back as metadata:
+      // the note deletes itself on reload while the audit log records an
+      // ordinary edit. Same trick forged **Author:**/**AuthorType:**.
+      // The region ends only at its real terminator.
+      if (inContent) {
+        if (line === '## Edit History') {
+          inContent = false;
+          inHistory = true;
+        } else {
+          contentLines.push(line);
+        }
+        continue;
+      }
+
+      // Same for the history region, which echoes every past version of the
+      // content — so the identical injection arrives here too, one edit later.
+      // Nothing follows Edit History in the format, so everything from here is
+      // history: an entry header, or an entry's body.
+      if (inHistory) {
+        if (line.startsWith('### ')) {
+          // Close the previous entry before starting the next.
+          if (currentHistoryEntry && historyContentLines.length > 0) {
+            currentHistoryEntry.content = historyContentLines.join('\n').trim();
+          }
+          const match = line.substring(4).match(/^(.+?) - (.+?) - (.+)$/);
+          if (match) {
+            currentHistoryEntry = {
+              timestamp: match[1],
+              author: match[2],
+              action: match[3] as any,
+              content: ''
+            };
+            note.history!.push(currentHistoryEntry);
+            historyContentLines = [];
+          }
+        } else if (currentHistoryEntry && line !== '```') {
+          if (line || historyContentLines.length > 0) {
+            historyContentLines.push(line);
+          }
+        }
+        continue;
+      }
+
       // Parse file path
       if (line.startsWith('**File:**')) {
         note.filePath = line.substring(9).trim();
@@ -423,40 +469,6 @@ export class StorageManager implements NoteStorage {
       else if (line === '## Edit History') {
         inContent = false;
         inHistory = true;
-      }
-      // Content lines (capture everything including blank lines)
-      else if (inContent && !line.startsWith('##')) {
-        contentLines.push(line);
-      }
-      // History entry header
-      else if (inHistory && line.startsWith('### ')) {
-        // Save previous history entry if exists
-        if (currentHistoryEntry && historyContentLines.length > 0) {
-          currentHistoryEntry.content = historyContentLines.join('\n').trim();
-        }
-
-        // Parse: ### timestamp - author - action
-        const match = line.substring(4).match(/^(.+?) - (.+?) - (.+)$/);
-        if (match) {
-          currentHistoryEntry = {
-            timestamp: match[1],
-            author: match[2],
-            action: match[3] as any,
-            content: ''
-          };
-          note.history!.push(currentHistoryEntry);
-          historyContentLines = [];
-        }
-      }
-      // History content in code block
-      else if (inHistory && currentHistoryEntry) {
-        if (line === '```') {
-          // Skip code fence markers
-          continue;
-        }
-        if (line || historyContentLines.length > 0) {
-          historyContentLines.push(line);
-        }
       }
     }
 

--- a/packages/code-notes-core/src/storageManager.ts
+++ b/packages/code-notes-core/src/storageManager.ts
@@ -457,9 +457,10 @@ export class StorageManager implements NoteStorage {
     let contentLineCount = 0;
     let i = 0;
 
+    let sawContentSection = false;
     for (; i < lines.length; i++) {
       const line = lines[i];
-      if (line === '## Current Content') break;
+      if (line === '## Current Content') { sawContentSection = true; break; }
       if (line === '**Format:** 2') continue;
       if (line.startsWith('**Content Lines:**')) {
         contentLineCount = parseInt(line.substring(18).trim(), 10) || 0;
@@ -468,10 +469,16 @@ export class StorageManager implements NoteStorage {
       this.applyMetadataLine(note, line);
     }
 
-    // '## Current Content', then one blank separator, then exactly N lines.
-    i += 2;
-    note.content = lines.slice(i, i + contentLineCount).join('\n');
-    i += contentLineCount;
+    // Only set content if the section was actually present. An empty content
+    // section is a valid empty note; a *missing* one is a corrupt file, and
+    // leaving content undefined lets isValidNote reject it rather than
+    // silently accept a blank note (or, worse, drop a real one on reload).
+    if (sawContentSection) {
+      // '## Current Content', then one blank separator, then exactly N lines.
+      i += 2;
+      note.content = lines.slice(i, i + contentLineCount).join('\n');
+      i += contentLineCount;
+    }
 
     while (i < lines.length && lines[i] !== '## Edit History') i++;
     i++;
@@ -501,7 +508,10 @@ export class StorageManager implements NoteStorage {
   private isValidNote(note: Partial<Note>): note is Note {
     return !!(
       note.id &&
-      note.content &&
+      // Empty-string content is a valid (contentless) note; only a missing
+      // content section — undefined — is invalid. The extension supports
+      // notes whose content is filled in later, and they must survive reload.
+      note.content !== undefined &&
       note.author &&
       note.filePath &&
       note.lineRange &&

--- a/packages/code-notes-core/src/types.ts
+++ b/packages/code-notes-core/src/types.ts
@@ -164,6 +164,15 @@ export interface CreateNoteParams {
   content: string;
   /** Optional author override */
   author?: string;
+  /** Optional metadata, applied in the same write as the note itself. */
+  type?: NoteType;
+  tags?: string[];
+  scope?: NoteScope;
+  references?: NoteReference[];
+  priority?: NotePriority;
+  expiresAt?: string;
+  /** 'agent' marks this as an agent write — the trust router keys off it. */
+  authorType?: AuthorType;
 }
 
 /**

--- a/packages/code-notes-core/src/types.ts
+++ b/packages/code-notes-core/src/types.ts
@@ -250,3 +250,61 @@ export interface HistoryStore {
   get<T>(key: string): T | undefined;
   update(key: string, value: unknown): Promise<void> | PromiseLike<void>;
 }
+
+/**
+ * How agent-authored writes are handled. Lives in the workspace's
+ * config.json, never in an agent's CLI flags — an agent that picks its own
+ * mode has no rails.
+ */
+export type AgentWriteMode = 'direct' | 'audit' | 'queue';
+
+/** Workspace-owned settings shared by the extension and the MCP server. */
+export interface WorkspaceConfig {
+  agentWriteMode: AgentWriteMode;
+  /** Informational, not a security boundary: writes from agents not listed are rejected. Empty = allow all. */
+  agentAllowList: string[];
+  /** Audit log rotates once it exceeds this many entries. */
+  auditLogRetention: number;
+}
+
+/**
+ * One agent operation, as written to `<storageDir>/_audit.log` (JSONL).
+ * Carries enough to display the op and to reverse it: create reverses to
+ * delete; edit and delete restore from the note's `history[]`.
+ */
+export interface AuditEntry {
+  ts: string;
+  op: 'create' | 'edit' | 'delete';
+  noteId: string;
+  agent: string;
+  file: string;
+  lineRange?: [number, number];
+  type?: NoteType;
+  /** sha256 of the note's *content* before/after an edit — for display and
+   *  stale-proposal detection. Distinct from Note.contentHash, which hashes
+   *  the *code* the note is attached to. */
+  prevContentHash?: string;
+  newContentHash?: string;
+}
+
+/**
+ * An agent write held for human approval, stored at
+ * `<storageDir>/_pending/<proposalId>.md`. `_pending/` is a subdirectory, and
+ * StorageManager.getAllNoteFiles() reads only the top level — that is what
+ * keeps proposals from loading as real notes. Do not flatten this.
+ */
+export interface Proposal {
+  proposalId: string;
+  op: 'create' | 'edit' | 'delete';
+  /** Present for edit/delete. */
+  targetNoteId?: string;
+  file: string;
+  lineRange?: LineRange;
+  agent: string;
+  proposedAt: string;
+  /** The proposed note body. Empty for a delete proposal. */
+  content: string;
+  /** sha256 of the target note's content when proposed — lets approve detect
+   *  that a human changed the note in the meantime. */
+  targetContentHash?: string;
+}

--- a/packages/code-notes-core/src/types.ts
+++ b/packages/code-notes-core/src/types.ts
@@ -15,7 +15,7 @@ export interface LineRange {
 /**
  * Action type for note history entries
  */
-export type NoteAction = 'created' | 'edited' | 'deleted';
+export type NoteAction = 'created' | 'edited' | 'deleted' | 'restored';
 
 /**
  * Type of note — drives prioritization in agent-facing exports
@@ -189,6 +189,9 @@ export interface UpdateNoteParams {
   content: string;
   /** Optional author override */
   author?: string;
+  /** Set when a human approves an agent's queued edit proposal. Not exposed
+   *  by the MCP edit_note tool, so an agent cannot forge it. */
+  approvedBy?: string;
 }
 
 /**

--- a/packages/code-notes-core/src/types.ts
+++ b/packages/code-notes-core/src/types.ts
@@ -106,6 +106,8 @@ export interface Note {
   expiresAt?: string;          // ISO 8601
   authorType?: AuthorType;
   priority?: NotePriority;
+  /** Set when a human approved an agent's queued proposal. */
+  approvedBy?: string;
 }
 
 /**
@@ -173,6 +175,8 @@ export interface CreateNoteParams {
   expiresAt?: string;
   /** 'agent' marks this as an agent write — the trust router keys off it. */
   authorType?: AuthorType;
+  /** Set when a human approved an agent's queued proposal. */
+  approvedBy?: string;
 }
 
 /**

--- a/packages/code-notes-core/src/workspaceConfig.ts
+++ b/packages/code-notes-core/src/workspaceConfig.ts
@@ -1,0 +1,67 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import type { AgentWriteMode, WorkspaceConfig } from './types.js';
+
+const CONFIG_FILE = 'config.json';
+const MODES: AgentWriteMode[] = ['direct', 'audit', 'queue'];
+
+/** Safe by default: agent writes are logged and reviewable unless a workspace opts out. */
+export const DEFAULT_WORKSPACE_CONFIG: WorkspaceConfig = {
+  agentWriteMode: 'audit',
+  agentAllowList: [],
+  auditLogRetention: 1000,
+};
+
+export function getConfigPath(storagePath: string): string {
+  return path.join(storagePath, CONFIG_FILE);
+}
+
+/**
+ * Read the workspace config, falling back to defaults field-by-field. A
+ * malformed or partial config must never break note-taking: the worst case
+ * is that the workspace runs in the default (audit) mode.
+ */
+export async function readWorkspaceConfig(storagePath: string): Promise<WorkspaceConfig> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(getConfigPath(storagePath), 'utf-8');
+  } catch {
+    return { ...DEFAULT_WORKSPACE_CONFIG };
+  }
+
+  let parsed: Partial<WorkspaceConfig>;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    console.warn(`[code-notes-core] ignoring malformed ${CONFIG_FILE}: ${(e as Error).message}`);
+    return { ...DEFAULT_WORKSPACE_CONFIG };
+  }
+
+  const mode = parsed.agentWriteMode;
+  if (mode !== undefined && !MODES.includes(mode)) {
+    console.warn(`[code-notes-core] unknown agentWriteMode "${mode}" — using "${DEFAULT_WORKSPACE_CONFIG.agentWriteMode}"`);
+  }
+
+  // This file is hand-edited and travels in the repo, so treat it as untrusted
+  // input: a value that merely has the right typeof still has to make sense.
+  const allowList = parsed.agentAllowList;
+  const retention = parsed.auditLogRetention;
+
+  return {
+    agentWriteMode: mode !== undefined && MODES.includes(mode) ? mode : DEFAULT_WORKSPACE_CONFIG.agentWriteMode,
+    agentAllowList: Array.isArray(allowList) && allowList.every(a => typeof a === 'string')
+      ? allowList
+      : DEFAULT_WORKSPACE_CONFIG.agentAllowList,
+    // <= 0 would rotate the whole log on every append. Number.isFinite is
+    // belt-and-braces for programmatic callers — NaN/Infinity can't survive
+    // JSON.parse, so a config file can't get them here.
+    auditLogRetention: typeof retention === 'number' && Number.isFinite(retention) && retention > 0
+      ? retention
+      : DEFAULT_WORKSPACE_CONFIG.auditLogRetention,
+  };
+}
+
+export async function writeWorkspaceConfig(storagePath: string, config: WorkspaceConfig): Promise<void> {
+  await fs.mkdir(storagePath, { recursive: true });
+  await fs.writeFile(getConfigPath(storagePath), `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
+}

--- a/packages/code-notes-core/test/auditLog.test.ts
+++ b/packages/code-notes-core/test/auditLog.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import { AuditLog, hashNoteContent } from '../src/auditLog.js';
+import { LockManager } from '../src/lockManager.js';
+import type { AuditEntry } from '../src/types.js';
+
+const entry = (noteId: string, op: AuditEntry['op'] = 'create'): AuditEntry => ({
+  ts: '2026-07-17T00:00:00.000Z',
+  op,
+  noteId,
+  agent: 'claude-code',
+  file: 'src/app.ts',
+});
+
+describe('AuditLog', () => {
+  let tempDir: string;
+  let logPath: string;
+  let log: AuditLog;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'audit-log-test-'));
+    logPath = path.join(tempDir, '_audit.log');
+    log = new AuditLog(logPath, { lockManager: new LockManager(path.join(tempDir, '.locks'), 'test') });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns an empty list when the log does not exist yet', async () => {
+    expect(await log.read()).toEqual([]);
+  });
+
+  it('appends entries as one JSON line each and reads them back newest-first', async () => {
+    await log.append(entry('note-1'));
+    await log.append(entry('note-2', 'edit'));
+
+    const raw = await fs.readFile(logPath, 'utf-8');
+    expect(raw.trimEnd().split('\n')).toHaveLength(2);
+
+    const entries = await log.read();
+    expect(entries.map(e => e.noteId)).toEqual(['note-2', 'note-1']);
+    expect(entries[0].op).toBe('edit');
+  });
+
+  it('does not interleave lines when many appends race', async () => {
+    await Promise.all(Array.from({ length: 50 }, (_, i) => log.append(entry(`note-${i}`))));
+
+    const entries = await log.read();
+    expect(entries).toHaveLength(50);
+    // Every line parsed => no torn writes.
+    expect(new Set(entries.map(e => e.noteId)).size).toBe(50);
+  });
+
+  it('skips unparseable lines instead of throwing, warning once', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await log.append(entry('note-1'));
+    await fs.appendFile(logPath, 'this is not json\n');
+    await log.append(entry('note-2'));
+
+    const entries = await log.read();
+    expect(entries.map(e => e.noteId)).toEqual(['note-2', 'note-1']);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('1');
+  });
+
+  it('rotates to _audit.log.1 once retention is exceeded', async () => {
+    const small = new AuditLog(logPath, {
+      lockManager: new LockManager(path.join(tempDir, '.locks'), 'test'),
+      retention: 3,
+    });
+    for (let i = 0; i < 5; i++) await small.append(entry(`note-${i}`));
+
+    const kept = await small.read();
+    expect(kept.length).toBeLessThanOrEqual(3);
+    // Nothing is lost — rotated lines are still on disk.
+    const rotated = await fs.readFile(`${logPath}.1`, 'utf-8');
+    expect(rotated).toContain('note-0');
+  });
+
+  it('truncate empties the log', async () => {
+    await log.append(entry('note-1'));
+    await log.truncate();
+    expect(await log.read()).toEqual([]);
+  });
+
+  it('hashNoteContent is stable and content-sensitive', () => {
+    expect(hashNoteContent('hello')).toBe(hashNoteContent('hello'));
+    expect(hashNoteContent('hello')).not.toBe(hashNoteContent('world'));
+  });
+});

--- a/packages/code-notes-core/test/auditLog.test.ts
+++ b/packages/code-notes-core/test/auditLog.test.ts
@@ -67,24 +67,28 @@ describe('AuditLog', () => {
     expect(warn.mock.calls[0][0]).toContain('1');
   });
 
-  it('rotates to _audit.log.1 once retention is exceeded', async () => {
+  it('rolls the whole log to _audit.log.1 past retention, losing nothing', async () => {
     const small = new AuditLog(logPath, {
       lockManager: new LockManager(path.join(tempDir, '.locks'), 'test'),
       retention: 3,
     });
     for (let i = 0; i < 5; i++) await small.append(entry(`note-${i}`));
 
-    const kept = await small.read();
-    expect(kept.length).toBeLessThanOrEqual(3);
-    // Nothing is lost — rotated lines are still on disk.
-    const rotated = await fs.readFile(`${logPath}.1`, 'utf-8');
-    expect(rotated).toContain('note-0');
-  });
+    const live = (await fs.readFile(logPath, 'utf-8')).split('\n').filter(l => l.trim());
+    expect(live.length).toBeLessThanOrEqual(3);
+    expect(await fs.readFile(`${logPath}.1`, 'utf-8')).toContain('note-0');
+    expect((await small.read()).map(e => e.noteId).sort()).toEqual(
+      ['note-0', 'note-1', 'note-2', 'note-3', 'note-4'],
+    );
+  }, 20_000);
 
   it('loses no entry when appends race a rotation across processes', async () => {
-    // Two AuditLog instances = two processes sharing one log and one lock dir.
-    // Retention is tiny so rotation fires constantly, maximizing the window
-    // where a read-modify-write rotation could clobber a concurrent append.
+    // Two AuditLog instances = two processes on one log. Retention is tiny so
+    // rotation fires constantly, maximising the window a rewrite-style
+    // rotation would have used to clobber a concurrent append. The rename is
+    // atomic, so every line must survive in one generation or the other —
+    // and unlike the old lock-on-append design, this holds under load rather
+    // than only on a quiet machine.
     const locksDir = path.join(tempDir, '.locks');
     const mk = () => new AuditLog(logPath, {
       lockManager: new LockManager(locksDir, 'test'),
@@ -98,58 +102,22 @@ describe('AuditLog', () => {
       Array.from({ length: total }, (_, i) => (i % 2 ? a : b).append(entry(`note-${i}`))),
     );
 
-    // Every line must survive somewhere — the live log or the rotated file.
-    const live = await fs.readFile(logPath, 'utf-8');
-    const rotated = await fs.readFile(`${logPath}.1`, 'utf-8').catch(() => '');
-    const ids = new Set(
-      `${rotated}\n${live}`
-        .split('\n')
-        .filter(l => l.trim())
-        .map(l => JSON.parse(l).noteId),
-    );
+    const ids = new Set((await a.read()).map(e => e.noteId));
     expect(ids.size).toBe(total);
   }, 20_000);
 
-  it('waits for the rotation lock instead of appending around it', async () => {
-    // The bug this guards: if append() writes without taking the lock, a
-    // rotation in another process can read, have this line land, then write
-    // its truncated copy back over it — silently losing the entry.
+  it('is not blocked by a held rotation lock', async () => {
+    // Appends are lock-free on purpose: an agent's note write must never wait
+    // on (or fail over) the audit lock. Nothing can clobber the line because
+    // rotation renames rather than rewrites.
     const locks = new LockManager(path.join(tempDir, '.locks'), 'rotator', { retryMs: 5_000 });
-    const writer = new AuditLog(logPath, {
-      lockManager: new LockManager(path.join(tempDir, '.locks'), 'writer', { retryMs: 5_000 }),
-      retention: 1000,
-    });
-
-    await locks.acquire('_audit');
-    const pending = writer.append(entry('note-serialized'));
-
-    // Give a lock-free implementation every chance to write anyway.
-    await new Promise(r => setTimeout(r, 200));
-    expect(await log.read()).toEqual([]);
-
-    await locks.release('_audit');
-    await pending;
-    expect((await log.read()).map(e => e.noteId)).toEqual(['note-serialized']);
-  }, 20_000);
-
-  it('still records the entry rather than failing the write when the lock never frees', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const locks = new LockManager(path.join(tempDir, '.locks'), 'stuck', { retryMs: 50 });
-    const held = new AuditLog(logPath, {
-      lockManager: new LockManager(path.join(tempDir, '.locks'), 'writer', { retryMs: 50 }),
-      retention: 1000,
-    });
-
-    // A jammed audit lock must never cost an agent its note write.
     await locks.acquire('_audit');
     try {
-      await held.append(entry('note-under-contention'));
+      await log.append(entry('note-during-lock'));
+      expect((await log.read()).map(e => e.noteId)).toEqual(['note-during-lock']);
     } finally {
       await locks.release('_audit');
     }
-
-    expect((await held.read()).map(e => e.noteId)).toEqual(['note-under-contention']);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('lock-free'));
   }, 20_000);
 
   it('truncate empties the log', async () => {

--- a/packages/code-notes-core/test/auditLog.test.ts
+++ b/packages/code-notes-core/test/auditLog.test.ts
@@ -81,6 +81,77 @@ describe('AuditLog', () => {
     expect(rotated).toContain('note-0');
   });
 
+  it('loses no entry when appends race a rotation across processes', async () => {
+    // Two AuditLog instances = two processes sharing one log and one lock dir.
+    // Retention is tiny so rotation fires constantly, maximizing the window
+    // where a read-modify-write rotation could clobber a concurrent append.
+    const locksDir = path.join(tempDir, '.locks');
+    const mk = () => new AuditLog(logPath, {
+      lockManager: new LockManager(locksDir, 'test'),
+      retention: 2,
+    });
+    const a = mk();
+    const b = mk();
+
+    const total = 40;
+    await Promise.all(
+      Array.from({ length: total }, (_, i) => (i % 2 ? a : b).append(entry(`note-${i}`))),
+    );
+
+    // Every line must survive somewhere — the live log or the rotated file.
+    const live = await fs.readFile(logPath, 'utf-8');
+    const rotated = await fs.readFile(`${logPath}.1`, 'utf-8').catch(() => '');
+    const ids = new Set(
+      `${rotated}\n${live}`
+        .split('\n')
+        .filter(l => l.trim())
+        .map(l => JSON.parse(l).noteId),
+    );
+    expect(ids.size).toBe(total);
+  }, 20_000);
+
+  it('waits for the rotation lock instead of appending around it', async () => {
+    // The bug this guards: if append() writes without taking the lock, a
+    // rotation in another process can read, have this line land, then write
+    // its truncated copy back over it — silently losing the entry.
+    const locks = new LockManager(path.join(tempDir, '.locks'), 'rotator', { retryMs: 5_000 });
+    const writer = new AuditLog(logPath, {
+      lockManager: new LockManager(path.join(tempDir, '.locks'), 'writer', { retryMs: 5_000 }),
+      retention: 1000,
+    });
+
+    await locks.acquire('_audit');
+    const pending = writer.append(entry('note-serialized'));
+
+    // Give a lock-free implementation every chance to write anyway.
+    await new Promise(r => setTimeout(r, 200));
+    expect(await log.read()).toEqual([]);
+
+    await locks.release('_audit');
+    await pending;
+    expect((await log.read()).map(e => e.noteId)).toEqual(['note-serialized']);
+  }, 20_000);
+
+  it('still records the entry rather than failing the write when the lock never frees', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const locks = new LockManager(path.join(tempDir, '.locks'), 'stuck', { retryMs: 50 });
+    const held = new AuditLog(logPath, {
+      lockManager: new LockManager(path.join(tempDir, '.locks'), 'writer', { retryMs: 50 }),
+      retention: 1000,
+    });
+
+    // A jammed audit lock must never cost an agent its note write.
+    await locks.acquire('_audit');
+    try {
+      await held.append(entry('note-under-contention'));
+    } finally {
+      await locks.release('_audit');
+    }
+
+    expect((await held.read()).map(e => e.noteId)).toEqual(['note-under-contention']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('lock-free'));
+  }, 20_000);
+
   it('truncate empties the log', async () => {
     await log.append(entry('note-1'));
     await log.truncate();

--- a/packages/code-notes-core/test/noteManager.test.ts
+++ b/packages/code-notes-core/test/noteManager.test.ts
@@ -650,6 +650,96 @@ describe('NoteManager Test Suite', () => {
 
 			expect(await auditLog.read()).toEqual([]);
 		});
+
+		describe('queue mode', () => {
+			let store: ProposalStore;
+
+			const buildQueued = () => new NoteManager(
+				new StorageManager(tempDir, '.test-notes'),
+				new ContentHashTracker(),
+				new FakeAuthorProvider('claude-code'),
+				{ proposalStore: store, agentWriteMode: async () => 'queue', agentName: 'claude-code' },
+			);
+
+			beforeEach(() => {
+				store = new ProposalStore(path.join(tempDir, '.test-notes', '_pending'));
+			});
+
+			it('diverts an agent create to a proposal, writing no note', async () => {
+				const queued = buildQueued();
+				const doc = createMockDocument('line0\n');
+
+				await expect(queued.createNote({
+					content: 'proposed',
+					filePath: doc.uri.fsPath,
+					lineRange: { start: 0, end: 0 },
+					authorType: 'agent',
+				}, doc)).rejects.toBeInstanceOf(PendingWriteError);
+
+				// No note landed...
+				expect(await queued.getAllNotes()).toHaveLength(0);
+				// ...but a proposal did.
+				const proposals = await store.list();
+				expect(proposals).toHaveLength(1);
+				expect(proposals[0]).toMatchObject({ op: 'create', agent: 'claude-code', content: 'proposed' });
+			});
+
+			it('diverts an agent edit, leaving the live note untouched', async () => {
+				const doc = createMockDocument('line0\n');
+				// Seed a note that already belongs to the agent.
+				const seeded = await buildManager('direct').createNote({
+					content: 'original',
+					filePath: doc.uri.fsPath,
+					lineRange: { start: 0, end: 0 },
+					authorType: 'agent',
+				}, doc);
+
+				const queued = buildQueued();
+				await expect(queued.updateNote({ id: seeded.id, content: 'proposed edit' }, doc))
+					.rejects.toBeInstanceOf(PendingWriteError);
+
+				expect((await queued.getNoteByIdGlobal(seeded.id))!.content).toBe('original');
+				const proposals = await store.list();
+				expect(proposals[0]).toMatchObject({
+					op: 'edit',
+					targetNoteId: seeded.id,
+					content: 'proposed edit',
+				});
+				// The stale-target check at approve time depends on this.
+				expect(proposals[0].targetContentHash).toBeTruthy();
+			});
+
+			it('diverts an agent delete, leaving the live note undeleted', async () => {
+				const doc = createMockDocument('line0\n');
+				const seeded = await buildManager('direct').createNote({
+					content: 'keep me for now',
+					filePath: doc.uri.fsPath,
+					lineRange: { start: 0, end: 0 },
+					authorType: 'agent',
+				}, doc);
+
+				const queued = buildQueued();
+				await expect(queued.deleteNote(seeded.id, doc.uri.fsPath))
+					.rejects.toBeInstanceOf(PendingWriteError);
+
+				expect((await queued.getNoteByIdGlobal(seeded.id))!.isDeleted).toBe(false);
+				expect((await store.list())[0]).toMatchObject({ op: 'delete', targetNoteId: seeded.id });
+			});
+
+			it('lets a human write through untouched', async () => {
+				const queued = buildQueued();
+				const doc = createMockDocument('line0\n');
+
+				const note = await queued.createNote({
+					content: 'human note',
+					filePath: doc.uri.fsPath,
+					lineRange: { start: 0, end: 0 },
+				}, doc);
+
+				expect(note.content).toBe('human note');
+				expect(await store.list()).toEqual([]);
+			});
+		});
 	});
 
 	describe('Note History', () => {

--- a/packages/code-notes-core/test/noteManager.test.ts
+++ b/packages/code-notes-core/test/noteManager.test.ts
@@ -11,6 +11,8 @@ import { NoteManager } from '../src/noteManager.js';
 import { ContentHashTracker } from '../src/contentHashTracker.js';
 import { StorageManager } from '../src/storageManager.js';
 import { LockManager } from '../src/lockManager.js';
+import { AuditLog } from '../src/auditLog.js';
+import { ProposalStore, PendingWriteError } from '../src/proposalStore.js';
 import { CreateNoteParams, UpdateNoteParams, NoteDocument, AuthorProvider } from '../src/types.js';
 
 class FakeAuthorProvider implements AuthorProvider {
@@ -557,6 +559,96 @@ describe('NoteManager Test Suite', () => {
 			const notes2 = await noteManager.refreshNotesForFile(doc.uri.fsPath);
 
 			expect(notes1.length).toBe(notes2.length);
+		});
+	});
+
+	describe('Trust router', () => {
+		let auditLog: AuditLog;
+
+		const buildManager = (mode: 'direct' | 'audit') => new NoteManager(
+			new StorageManager(tempDir, '.test-notes'),
+			new ContentHashTracker(),
+			new FakeAuthorProvider('claude-code'),
+			{ auditLog, agentWriteMode: async () => mode, agentName: 'claude-code' },
+		);
+
+		beforeEach(() => {
+			auditLog = new AuditLog(path.join(tempDir, '.test-notes', '_audit.log'));
+		});
+
+		it('logs an agent create in audit mode', async () => {
+			const agentManager = buildManager('audit');
+			const doc = createMockDocument('line0\n');
+			const note = await agentManager.createNote({
+				content: 'agent note',
+				filePath: doc.uri.fsPath,
+				lineRange: { start: 0, end: 0 },
+				authorType: 'agent',
+			}, doc);
+
+			// The write still lands — audit logs, it doesn't block.
+			expect(await agentManager.getNoteByIdGlobal(note.id)).toBeTruthy();
+
+			const entries = await auditLog.read();
+			expect(entries).toHaveLength(1);
+			expect(entries[0]).toMatchObject({ op: 'create', noteId: note.id, agent: 'claude-code' });
+		});
+
+		it('logs an agent edit with before/after content hashes', async () => {
+			const agentManager = buildManager('audit');
+			const doc = createMockDocument('line0\n');
+			const note = await agentManager.createNote({
+				content: 'first',
+				filePath: doc.uri.fsPath,
+				lineRange: { start: 0, end: 0 },
+				authorType: 'agent',
+			}, doc);
+			await agentManager.updateNote({ id: note.id, content: 'second' }, doc);
+
+			const entries = await auditLog.read();
+			expect(entries[0].op).toBe('edit');
+			expect(entries[0].prevContentHash).toBeTruthy();
+			expect(entries[0].newContentHash).not.toBe(entries[0].prevContentHash);
+		});
+
+		it('logs an agent delete', async () => {
+			const agentManager = buildManager('audit');
+			const doc = createMockDocument('line0\n');
+			const note = await agentManager.createNote({
+				content: 'doomed',
+				filePath: doc.uri.fsPath,
+				lineRange: { start: 0, end: 0 },
+				authorType: 'agent',
+			}, doc);
+			await agentManager.deleteNote(note.id, doc.uri.fsPath);
+
+			const entries = await auditLog.read();
+			expect(entries[0]).toMatchObject({ op: 'delete', noteId: note.id });
+		});
+
+		it('does not log a human write, even in audit mode', async () => {
+			const agentManager = buildManager('audit');
+			const doc = createMockDocument('line0\n');
+			await agentManager.createNote({
+				content: 'human note',
+				filePath: doc.uri.fsPath,
+				lineRange: { start: 0, end: 0 },
+			}, doc);
+
+			expect(await auditLog.read()).toEqual([]);
+		});
+
+		it('does not log in direct mode', async () => {
+			const agentManager = buildManager('direct');
+			const doc = createMockDocument('line0\n');
+			await agentManager.createNote({
+				content: 'agent note',
+				filePath: doc.uri.fsPath,
+				lineRange: { start: 0, end: 0 },
+				authorType: 'agent',
+			}, doc);
+
+			expect(await auditLog.read()).toEqual([]);
 		});
 	});
 

--- a/packages/code-notes-core/test/noteManager.test.ts
+++ b/packages/code-notes-core/test/noteManager.test.ts
@@ -660,14 +660,23 @@ describe('NoteManager Test Suite', () => {
 			expect(entries[0]).toMatchObject({ op: 'delete', noteId: note.id });
 		});
 
-		it('does not log a human write, even in audit mode', async () => {
-			const agentManager = buildManager('audit');
+		// One instance, one identity: the extension's manager is a human's, so
+		// even sharing the audit log it must never record its own writes.
+		it('does not log a write from a non-agent manager, even in audit mode', async () => {
+			const humanManager = new NoteManager(
+				new StorageManager(tempDir, '.test-notes'),
+				new ContentHashTracker(),
+				new FakeAuthorProvider('a-human'),
+				{ auditLog, agentWriteMode: async () => 'audit', agentWriter: false },
+			);
 			const doc = createMockDocument('line0\n');
-			await agentManager.createNote({
+			const note = await humanManager.createNote({
 				content: 'human note',
 				filePath: doc.uri.fsPath,
 				lineRange: { start: 0, end: 0 },
 			}, doc);
+			await humanManager.updateNote({ id: note.id, content: 'human edit' }, doc);
+			await humanManager.deleteNote(note.id, doc.uri.fsPath);
 
 			expect(await auditLog.read()).toEqual([]);
 		});
@@ -760,17 +769,79 @@ describe('NoteManager Test Suite', () => {
 				expect((await store.list())[0]).toMatchObject({ op: 'delete', targetNoteId: seeded.id });
 			});
 
-			it('lets a human write through untouched', async () => {
-				const queued = buildQueued();
+			it('lets a non-agent manager write through untouched', async () => {
+				const humanManager = new NoteManager(
+					new StorageManager(tempDir, '.test-notes'),
+					new ContentHashTracker(),
+					new FakeAuthorProvider('a-human'),
+					{ proposalStore: store, agentWriteMode: async () => 'queue', agentWriter: false },
+				);
 				const doc = createMockDocument('line0\n');
 
-				const note = await queued.createNote({
+				const note = await humanManager.createNote({
 					content: 'human note',
 					filePath: doc.uri.fsPath,
 					lineRange: { start: 0, end: 0 },
 				}, doc);
 
 				expect(note.content).toBe('human note');
+				expect(await store.list()).toEqual([]);
+			});
+
+			// Identity comes from the writer, not the note. Keying off the note's
+			// authorType let an agent edit any human-authored note with no
+			// approval at all — the rails only covered notes agents had made
+			// themselves, which is exactly backwards for a shared codebase.
+			it('diverts an agent edit of a HUMAN-authored note', async () => {
+				const doc = createMockDocument('line0\n');
+				const humanNote = await noteManager.createNote({
+					content: 'human wrote this',
+					filePath: doc.uri.fsPath,
+					lineRange: { start: 0, end: 0 },
+				}, doc);
+
+				const agent = buildQueued();
+				await expect(agent.updateNote({ id: humanNote.id, content: 'agent rewrite' }, doc))
+					.rejects.toBeInstanceOf(PendingWriteError);
+
+				expect((await agent.getNoteByIdGlobal(humanNote.id))!.content).toBe('human wrote this');
+				expect((await store.list())[0]).toMatchObject({ op: 'edit', targetNoteId: humanNote.id });
+			});
+
+			it('diverts an agent delete of a HUMAN-authored note', async () => {
+				const doc = createMockDocument('line0\n');
+				const humanNote = await noteManager.createNote({
+					content: 'human wrote this',
+					filePath: doc.uri.fsPath,
+					lineRange: { start: 0, end: 0 },
+				}, doc);
+
+				const agent = buildQueued();
+				await expect(agent.deleteNote(humanNote.id, doc.uri.fsPath))
+					.rejects.toBeInstanceOf(PendingWriteError);
+
+				expect((await agent.getNoteByIdGlobal(humanNote.id))!.isDeleted).toBe(false);
+			});
+
+			// The mirror case: the extension has no agent wiring, so a human
+			// editing an agent's note (e.g. clicking Revert) must never be
+			// diverted into a proposal awaiting their own approval.
+			it('does not divert a human editing an AGENT-authored note', async () => {
+				const doc = createMockDocument('line0\n');
+				const agentNote = await buildManager('direct').createNote({
+					content: 'agent wrote this',
+					filePath: doc.uri.fsPath,
+					lineRange: { start: 0, end: 0 },
+					authorType: 'agent',
+				}, doc);
+
+				// noteManager is the extension's: no proposalStore, no agent wiring.
+				const reverted = await noteManager.updateNote(
+					{ id: agentNote.id, content: 'human reverted it' },
+					doc,
+				);
+
+				expect(reverted.content).toBe('human reverted it');
 				expect(await store.list()).toEqual([]);
 			});
 		});

--- a/packages/code-notes-core/test/noteManager.test.ts
+++ b/packages/code-notes-core/test/noteManager.test.ts
@@ -681,6 +681,29 @@ describe('NoteManager Test Suite', () => {
 			expect(await auditLog.read()).toEqual([]);
 		});
 
+		// These two write notes but are deliberately NOT routed through the
+		// trust model — they're human-only paths. Guard them so a future
+		// agent-facing caller fails loudly instead of silently bypassing.
+		it('refuses updateNoteMetadata and updateNotePositions from an agent manager', async () => {
+			const agentManager = buildManager('audit');
+			const doc = createMockDocument('line0\n');
+			const note = await agentManager.createNote({
+				content: 'agent note',
+				filePath: doc.uri.fsPath,
+				lineRange: { start: 0, end: 0 },
+				authorType: 'agent',
+			}, doc);
+
+			await expect(agentManager.updateNoteMetadata(note.id, { priority: 'high' }))
+				.rejects.toThrow(/not available to agent writers/);
+			await expect(agentManager.updateNotePositions(doc))
+				.rejects.toThrow(/not available to agent writers/);
+
+			// The human's manager still uses both freely.
+			await expect(noteManager.updateNoteMetadata(note.id, { priority: 'high' })).resolves.toBeTruthy();
+			await expect(noteManager.updateNotePositions(doc)).resolves.toBeInstanceOf(Array);
+		});
+
 		it('does not log in direct mode', async () => {
 			const agentManager = buildManager('direct');
 			const doc = createMockDocument('line0\n');

--- a/packages/code-notes-core/test/noteManager.test.ts
+++ b/packages/code-notes-core/test/noteManager.test.ts
@@ -11,7 +11,7 @@ import { NoteManager } from '../src/noteManager.js';
 import { ContentHashTracker } from '../src/contentHashTracker.js';
 import { StorageManager } from '../src/storageManager.js';
 import { LockManager } from '../src/lockManager.js';
-import { AuditLog } from '../src/auditLog.js';
+import { AuditLog, hashNoteContent } from '../src/auditLog.js';
 import { ProposalStore, PendingWriteError } from '../src/proposalStore.js';
 import { CreateNoteParams, UpdateNoteParams, NoteDocument, AuthorProvider } from '../src/types.js';
 
@@ -733,6 +733,52 @@ describe('NoteManager Test Suite', () => {
 
 			const entries = await auditLog.read();
 			expect(entries[0]).toMatchObject({ op: 'delete', noteId: note.id });
+		});
+
+		// Regression: reverting an agent edit that is NOT the note's latest change.
+		// The Agent activity view lets you Revert any listed entry, so a later
+		// edit (here a human's) may sit on top of the one being reverted. The
+		// revert must restore the version this edit replaced — identified by the
+		// entry's prevContentHash — not the positionally-second-to-last history
+		// entry, which after a later edit is the agent's own content.
+		it('an agent edit is reverted by prevContentHash, not by history position', async () => {
+			const agentManager = buildManager('audit');
+			const doc = createMockDocument('line0\n');
+			const note = await agentManager.createNote({
+				content: 'c0-original',
+				filePath: doc.uri.fsPath,
+				lineRange: { start: 0, end: 0 },
+				authorType: 'agent',
+			}, doc);
+
+			// The agent edit we will later revert (c0 -> c1).
+			await agentManager.updateNote({ id: note.id, content: 'c1-agent-edit' }, doc);
+
+			// A human edits afterwards (c1 -> c2), so the agent edit is no longer
+			// the note's most recent change. Human writes are not audited.
+			const humanManager = new NoteManager(
+				new StorageManager(tempDir, '.test-notes'),
+				new ContentHashTracker(),
+				new FakeAuthorProvider('a-human'),
+				{ auditLog, agentWriteMode: async () => 'audit', agentWriter: false },
+			);
+			await humanManager.updateNote({ id: note.id, content: 'c2-human-later-edit' }, doc);
+
+			// The audit log holds only the two agent ops; the edit is newest.
+			const editEntry = (await auditLog.read()).find(e => e.op === 'edit')!;
+			expect(editEntry.prevContentHash).toBe(hashNoteContent('c0-original'));
+
+			const reloaded = (await humanManager.getNoteByIdGlobal(note.id))!;
+
+			// What revertAgentOp does: locate the version this edit replaced.
+			const prior = reloaded.history.find(
+				h => hashNoteContent(h.content) === editEntry.prevContentHash,
+			);
+			expect(prior?.content).toBe('c0-original');
+
+			// The old positional approach (history[length - 2]) would restore the
+			// agent's own content instead — exactly the bug this guards against.
+			expect(reloaded.history[reloaded.history.length - 2].content).toBe('c1-agent-edit');
 		});
 
 		// One instance, one identity: the extension's manager is a human's, so

--- a/packages/code-notes-core/test/noteManager.test.ts
+++ b/packages/code-notes-core/test/noteManager.test.ts
@@ -331,6 +331,65 @@ describe('NoteManager Test Suite', () => {
 
 			await expect(noteManager.deleteNote(note.id, doc.uri.fsPath)).rejects.toThrow(/already deleted/);
 		});
+
+		// Reverting a delete (the audit-mode Revert button) is the path the
+		// whole-branch review found broken: getNoteByIdGlobal hid the note and
+		// updateNote refused it. These pin the primitives that fix supplies.
+		it('getNoteByIdIncludingDeleted returns a soft-deleted note', async () => {
+			const doc = createMockDocument('function test() {}');
+			const note = await noteManager.createNote({
+				content: 'to delete', filePath: doc.uri.fsPath, lineRange: { start: 0, end: 0 },
+			}, doc);
+			await noteManager.deleteNote(note.id, doc.uri.fsPath);
+
+			expect(await noteManager.getNoteByIdGlobal(note.id)).toBeUndefined();
+			const found = await noteManager.getNoteByIdIncludingDeleted(note.id);
+			expect(found).toBeTruthy();
+			expect(found!.isDeleted).toBe(true);
+			expect(found!.content).toBe('to delete');
+		});
+
+		it('undeleteNote restores a deleted note with its content and a history entry', async () => {
+			const doc = createMockDocument('function test() {}');
+			const note = await noteManager.createNote({
+				content: 'important note', filePath: doc.uri.fsPath, lineRange: { start: 0, end: 0 },
+			}, doc);
+			await noteManager.deleteNote(note.id, doc.uri.fsPath);
+
+			const restored = await noteManager.undeleteNote(note.id);
+			expect(restored.isDeleted).toBe(false);
+			expect(restored.content).toBe('important note');
+			// visible again through the normal lookup, and it survives a reload
+			expect(await noteManager.getNoteByIdGlobal(note.id)).toBeTruthy();
+			const onDisk = await noteManager.getNoteByIdGlobal(note.id);
+			expect(onDisk!.isDeleted).toBe(false);
+			// the restore is recorded, not silent
+			expect(restored.history[restored.history.length - 1].action).toBe('edited');
+		});
+
+		it('undeleteNote rejects a note that is not deleted', async () => {
+			const doc = createMockDocument('function test() {}');
+			const note = await noteManager.createNote({
+				content: 'live', filePath: doc.uri.fsPath, lineRange: { start: 0, end: 0 },
+			}, doc);
+			await expect(noteManager.undeleteNote(note.id)).rejects.toThrow(/not deleted/);
+		});
+
+		it('undeleteNote is blocked for an agent writer', async () => {
+			const doc = createMockDocument('function test() {}');
+			const note = await noteManager.createNote({
+				content: 'x', filePath: doc.uri.fsPath, lineRange: { start: 0, end: 0 },
+			}, doc);
+			await noteManager.deleteNote(note.id, doc.uri.fsPath);
+
+			const agentManager = new NoteManager(
+				new StorageManager(tempDir, '.test-notes'),
+				new ContentHashTracker(),
+				new FakeAuthorProvider('claude-code'),
+				{ agentWriter: true, auditLog: new AuditLog(path.join(tempDir, '.test-notes', '_audit.log')) },
+			);
+			await expect(agentManager.undeleteNote(note.id)).rejects.toThrow(/not available to agent writers/);
+		});
 	});
 
 	describe('Note Retrieval', () => {

--- a/packages/code-notes-core/test/noteManager.test.ts
+++ b/packages/code-notes-core/test/noteManager.test.ts
@@ -51,6 +51,30 @@ describe('NoteManager Test Suite', () => {
 	});
 
 	describe('Note Creation', () => {
+		it('applies metadata in the single create write, with no second save', async () => {
+			const doc = createMockDocument('line0\nline1\n');
+			const note = await noteManager.createNote({
+				content: 'Watch out',
+				filePath: doc.uri.fsPath,
+				lineRange: { start: 0, end: 0 },
+				type: 'warning',
+				tags: ['security'],
+				priority: 'high',
+				authorType: 'agent',
+			}, doc);
+
+			expect(note.type).toBe('warning');
+			expect(note.tags).toEqual(['security']);
+			expect(note.priority).toBe('high');
+			expect(note.authorType).toBe('agent');
+			// One write means one history entry — a second save would add another.
+			expect(note.history).toHaveLength(1);
+
+			const onDisk = await noteManager.getNoteByIdGlobal(note.id);
+			expect(onDisk!.type).toBe('warning');
+			expect(onDisk!.authorType).toBe('agent');
+		});
+
 		it('should create a new note', async () => {
 			const doc = createMockDocument('function test() {\n  return true;\n}');
 			const params: CreateNoteParams = {

--- a/packages/code-notes-core/test/noteManager.test.ts
+++ b/packages/code-notes-core/test/noteManager.test.ts
@@ -199,6 +199,22 @@ describe('NoteManager Test Suite', () => {
 			expect(updatedNote.history[1].content).toBe('Updated content');
 		});
 
+		it('records approvedBy on an update when supplied (approved edit proposal)', async () => {
+			const doc = createMockDocument('function test() {}');
+			const note = await noteManager.createNote({
+				content: 'original', filePath: doc.uri.fsPath, lineRange: { start: 0, end: 0 },
+			}, doc);
+
+			const updated = await noteManager.updateNote(
+				{ id: note.id, content: 'approved edit', author: 'Jane Dev', approvedBy: 'Jane Dev' },
+				doc,
+			);
+			expect(updated.approvedBy).toBe('Jane Dev');
+			// survives a reload
+			const onDisk = await noteManager.getNoteByIdGlobal(note.id);
+			expect(onDisk!.approvedBy).toBe('Jane Dev');
+		});
+
 		it('should trim updated content', async () => {
 			const doc = createMockDocument('function test() {}');
 			const note = await noteManager.createNote({
@@ -363,8 +379,8 @@ describe('NoteManager Test Suite', () => {
 			expect(await noteManager.getNoteByIdGlobal(note.id)).toBeTruthy();
 			const onDisk = await noteManager.getNoteByIdGlobal(note.id);
 			expect(onDisk!.isDeleted).toBe(false);
-			// the restore is recorded, not silent
-			expect(restored.history[restored.history.length - 1].action).toBe('edited');
+			// the restore is recorded with its own action, not disguised as an edit
+			expect(restored.history[restored.history.length - 1].action).toBe('restored');
 		});
 
 		it('undeleteNote rejects a note that is not deleted', async () => {

--- a/packages/code-notes-core/test/noteManager.test.ts
+++ b/packages/code-notes-core/test/noteManager.test.ts
@@ -562,6 +562,40 @@ describe('NoteManager Test Suite', () => {
 		});
 	});
 
+	describe('Position updates', () => {
+		it('does not clobber a concurrent content edit made by another process', async () => {
+			// Note attached to line 0; later the same text moves to line 2.
+			const before = createMockDocument('target line\nfiller\nfiller\n');
+			const note = await noteManager.createNote({
+				content: 'original',
+				filePath: before.uri.fsPath,
+				lineRange: { start: 0, end: 0 }
+			}, before);
+
+			// Another process edits the note's *content* while our cache is warm.
+			const other = new NoteManager(
+				new StorageManager(tempDir, '.test-notes'),
+				new ContentHashTracker(),
+				new FakeAuthorProvider('agent'),
+			);
+			await other.updateNote({ id: note.id, content: 'edited elsewhere' }, before);
+
+			// The code moves down two lines, so repositioning kicks in.
+			const after = createMockDocument('new\nnew\ntarget line\n', before.uri.fsPath);
+			await noteManager.updateNotePositions(after);
+
+			const fresh = new NoteManager(
+				new StorageManager(tempDir, '.test-notes'),
+				new ContentHashTracker(),
+				new FakeAuthorProvider('x'),
+			);
+			const final = await fresh.getNoteByIdGlobal(note.id);
+			// Repositioning must move the note WITHOUT resurrecting stale content.
+			expect(final!.content).toBe('edited elsewhere');
+			expect(final!.lineRange.start).toBe(2);
+		});
+	});
+
 	describe('Trust router', () => {
 		let auditLog: AuditLog;
 
@@ -926,9 +960,11 @@ describe('NoteManager Test Suite', () => {
  */
 let mockDocumentSeq = 0;
 
-function createMockDocument(content: string): NoteDocument {
+// atPath lets a test model the same file changing over time — notes are keyed
+// to uri.fsPath, so "the code moved" needs two documents sharing one path.
+function createMockDocument(content: string, atPath?: string): NoteDocument {
 	const lines = content.split('\n');
-	const filePath = `/test/file-${Date.now()}-${++mockDocumentSeq}.ts`;
+	const filePath = atPath ?? `/test/file-${Date.now()}-${++mockDocumentSeq}.ts`;
 
 	return {
 		lineCount: lines.length,

--- a/packages/code-notes-core/test/proposalStore.test.ts
+++ b/packages/code-notes-core/test/proposalStore.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import { ProposalStore } from '../src/proposalStore.js';
+import type { Proposal } from '../src/types.js';
+
+const proposal = (id: string): Proposal => ({
+  proposalId: id,
+  op: 'create',
+  file: 'src/app.ts',
+  lineRange: { start: 1, end: 2 },
+  agent: 'claude-code',
+  proposedAt: '2026-07-17T00:00:00.000Z',
+  content: 'proposed note body',
+});
+
+describe('ProposalStore', () => {
+  let tempDir: string;
+  let store: ProposalStore;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'proposal-test-'));
+    store = new ProposalStore(path.join(tempDir, '_pending'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns an empty list before anything is proposed', async () => {
+    expect(await store.list()).toEqual([]);
+  });
+
+  it('round-trips a proposal through disk', async () => {
+    await store.save(proposal('prop-1'));
+    const loaded = await store.load('prop-1');
+    expect(loaded).toMatchObject({
+      proposalId: 'prop-1',
+      op: 'create',
+      file: 'src/app.ts',
+      agent: 'claude-code',
+      content: 'proposed note body',
+    });
+    expect(loaded!.lineRange).toEqual({ start: 1, end: 2 });
+  });
+
+  it('lists proposals oldest-first', async () => {
+    await store.save({ ...proposal('prop-1'), proposedAt: '2026-07-17T00:00:01.000Z' });
+    await store.save({ ...proposal('prop-2'), proposedAt: '2026-07-17T00:00:00.000Z' });
+    expect((await store.list()).map(p => p.proposalId)).toEqual(['prop-2', 'prop-1']);
+  });
+
+  it('reject moves the file to .rejected/ rather than deleting it', async () => {
+    await store.save(proposal('prop-1'));
+    await store.reject('prop-1');
+
+    expect(await store.load('prop-1')).toBeNull();
+    expect(await store.list()).toEqual([]);
+    const rejected = await fs.readFile(path.join(tempDir, '_pending', '.rejected', 'prop-1.md'), 'utf-8');
+    expect(rejected).toContain('proposed note body');
+  });
+
+  it('keeps rejected proposals out of the live queue even with others pending', async () => {
+    await store.save(proposal('prop-1'));
+    await store.save(proposal('prop-2'));
+    await store.reject('prop-1');
+
+    // The .rejected/ dir lives inside _pending/; a rejected proposal must
+    // never come back through list().
+    expect((await store.list()).map(p => p.proposalId)).toEqual(['prop-2']);
+  });
+
+  it('remove deletes an applied proposal', async () => {
+    await store.save(proposal('prop-1'));
+    await store.remove('prop-1');
+    expect(await store.load('prop-1')).toBeNull();
+  });
+
+  it('skips an unparseable proposal file instead of failing the whole list', async () => {
+    await store.save(proposal('prop-1'));
+    await fs.writeFile(path.join(tempDir, '_pending', 'garbage.md'), 'no frontmatter here');
+    expect((await store.list()).map(p => p.proposalId)).toEqual(['prop-1']);
+  });
+});

--- a/packages/code-notes-core/test/proposalStore.test.ts
+++ b/packages/code-notes-core/test/proposalStore.test.ts
@@ -82,4 +82,16 @@ describe('ProposalStore', () => {
     await fs.writeFile(path.join(tempDir, '_pending', 'garbage.md'), 'no frontmatter here');
     expect((await store.list()).map(p => p.proposalId)).toEqual(['prop-1']);
   });
+
+  it('a file value containing a frontmatter delimiter cannot split the frontmatter', async () => {
+    // file is agent-controllable via create_note; a newline + '---' in it must
+    // not close the frontmatter early and hijack the content/fields.
+    const evil = 'src/a.ts\n---\ninjected body\nop: delete';
+    await store.save({ ...proposal('prop-evil'), file: evil, content: 'the real proposed note' });
+
+    const loaded = await store.load('prop-evil');
+    expect(loaded!.file).toBe(evil);
+    expect(loaded!.op).toBe('create');
+    expect(loaded!.content).toBe('the real proposed note');
+  });
 });

--- a/packages/code-notes-core/test/storageManager.test.ts
+++ b/packages/code-notes-core/test/storageManager.test.ts
@@ -518,5 +518,89 @@ Hi.
 
 			expect(loaded!.content).toBe('## Heading\nbody text');
 		});
+
+	describe('Storage format v2 (length-delimited)', () => {
+		// Frozen output of the v0.4-era serializer. This is the migration gate:
+		// a real user's on-disk note must still load after the format change.
+		const V1_FIXTURE = [
+			'# Code Context Note', '',
+			'**File:** /src/app.ts',
+			'**Lines:** 5-7',
+			'**Content Hash:** abc123', '',
+			'## Note: freeze-1',
+			'**Author:** Jane Dev',
+			'**Created:** 2026-05-01T10:00:00.000Z',
+			'**Updated:** 2026-05-02T11:00:00.000Z',
+			'**Type:** warning',
+			'**Priority:** high',
+			'**Tags:** security, auth',
+			'**AuthorType:** agent', '',
+			'## Current Content', '',
+			'first line of content', '',
+			'third line after a blank', '',
+			'## Edit History', '',
+			'Complete chronological history of all edits to this code location:', '',
+			'### 2026-05-01T10:00:00.000Z - Jane Dev - created', '',
+			'BT', 'original body', 'BT', '',
+			'### 2026-05-02T11:00:00.000Z - claude-code - edited', '',
+			'BT', 'edited body', 'second edit line', 'BT', '',
+		].join('\n').replace(/BT/g, '```');
+
+		it('still reads a v1 (pre-v0.5) note, content and history intact', async () => {
+			const file = path.join(tempDir, '.test-notes', 'freeze-1.md');
+			await fs.mkdir(path.dirname(file), { recursive: true });
+			await fs.writeFile(file, V1_FIXTURE);
+
+			const loaded = await storageManager.loadNoteById('freeze-1');
+			expect(loaded).toBeTruthy();
+			expect(loaded!.content).toBe('first line of content\n\nthird line after a blank');
+			expect(loaded!.author).toBe('Jane Dev');
+			expect(loaded!.type).toBe('warning');
+			expect(loaded!.priority).toBe('high');
+			expect(loaded!.tags).toEqual(['security', 'auth']);
+			expect(loaded!.authorType).toBe('agent');
+			expect(loaded!.history.map(h => h.author)).toEqual(['Jane Dev', 'claude-code']);
+			expect(loaded!.history[1].content).toBe('edited body\nsecond edit line');
+		});
+
+		it('neutralizes a content line equal to "## Edit History" — no truncation, no forged history', async () => {
+			await storageManager.saveNote({
+				...testNote,
+				content: 'real content\n## Edit History\n\n### 2099 - HACKER - created\n\nforged',
+				history: [{ content: 'orig', author: 'me', timestamp: '2026-01-01T00:00:00Z', action: 'created' }],
+			});
+			const loaded = await storageManager.loadNoteById(testNote.id);
+			expect(loaded!.content).toBe('real content\n## Edit History\n\n### 2099 - HACKER - created\n\nforged');
+			expect(loaded!.history.map(h => h.author)).toEqual(['me']);
+		});
+
+		it('neutralizes a history entry that breaks out of its code fence', async () => {
+			await storageManager.saveNote({
+				...testNote,
+				content: 'clean',
+				history: [
+					{ content: 'first', author: 'me', timestamp: '2026-01-01T00:00:00Z', action: 'created' },
+					{ content: '```\n### 2099 - HACKER - edited\n```\ninjected', author: 'agent', timestamp: '2026-01-02T00:00:00Z', action: 'edited' },
+				],
+			});
+			const loaded = await storageManager.loadNoteById(testNote.id);
+			expect(loaded!.history.map(h => h.author)).toEqual(['me', 'agent']);
+			expect(loaded!.history[1].content).toBe('```\n### 2099 - HACKER - edited\n```\ninjected');
+		});
+
+		it.each([
+			['a delimiter-looking line', '## Current Content'],
+			['a metadata-looking line', '**AuthorType:** human'],
+			['a history header', '### a - b - c'],
+			['a bare fence', '```'],
+			['a blank line inside content', 'above\n\nbelow'],
+			['content starting with hash', '# real markdown heading'],
+			['content spoofing the line count field', '**Content Lines:** 999'],
+		])('round-trips content containing %s exactly', async (_label, content) => {
+			await storageManager.saveNote({ ...testNote, content });
+			const loaded = await storageManager.loadNoteById(testNote.id);
+			expect(loaded!.content).toBe(content);
+		});
+	});
 	});
 });

--- a/packages/code-notes-core/test/storageManager.test.ts
+++ b/packages/code-notes-core/test/storageManager.test.ts
@@ -485,6 +485,29 @@ Hi.
 		expect(loaded!.authorType).toBe('agent');
 	});
 
+	describe('Empty-content notes', () => {
+		it('an empty-content note survives a save/reload instead of vanishing', async () => {
+			await storageManager.saveNote({ ...testNote, content: '' });
+			const loaded = await storageManager.loadNoteById(testNote.id);
+			expect(loaded).toBeTruthy();
+			expect(loaded!.content).toBe('');
+		});
+
+		it('a file with no content section is still rejected as corrupt (not masked as empty)', async () => {
+			// v2 header only, no '## Current Content' section.
+			const corrupt = [
+				'# Code Context Note', '',
+				'**File:** /f.ts', '**Lines:** 1-1', '**Content Hash:** h', '',
+				'## Note: corrupt-1', '**Format:** 2', '**Author:** me',
+				'**Created:** t', '**Updated:** t',
+			].join('\n');
+			const file = path.join(tempDir, '.test-notes', 'corrupt-1.md');
+			await fs.mkdir(path.dirname(file), { recursive: true });
+			await fs.writeFile(file, corrupt);
+			expect(await storageManager.loadNoteById('corrupt-1')).toBeNull();
+		});
+	});
+
 	// Note content is agent-controlled input crossing a human review boundary.
 	// The metadata branches match on prefix, so content had to stop being
 	// re-parsed as metadata on reload.

--- a/packages/code-notes-core/test/storageManager.test.ts
+++ b/packages/code-notes-core/test/storageManager.test.ts
@@ -474,4 +474,39 @@ Hi.
 		expect(errors.length).toBe(1);
 		expect(errors[0].file).toBe('bad.md');
 	});
+
+	// Note content is agent-controlled input crossing a human review boundary.
+	// The metadata branches match on prefix, so content had to stop being
+	// re-parsed as metadata on reload.
+	describe('Content injection', () => {
+		it('does not let content beginning with **Status:** DELETED delete the note', async () => {
+			await storageManager.saveNote({ ...testNote, content: 'looks harmless\n**Status:** DELETED' });
+			const loaded = await storageManager.loadNoteById(testNote.id);
+
+			expect(loaded).toBeTruthy();
+			expect(loaded!.isDeleted).toBe(false);
+			expect(loaded!.content).toBe('looks harmless\n**Status:** DELETED');
+		});
+
+		it('does not let content forge author, authorType, or filePath', async () => {
+			await storageManager.saveNote({
+				...testNote,
+				authorType: 'agent',
+				content: 'ship it\n**Author:** Alice\n**AuthorType:** human\n**File:** /etc/passwd',
+			});
+			const loaded = await storageManager.loadNoteById(testNote.id);
+
+			expect(loaded!.author).toBe('Test Author');
+			expect(loaded!.authorType).toBe('agent');
+			expect(loaded!.filePath).toBe('/path/to/test/file.ts');
+			expect(loaded!.content).toContain('**Author:** Alice');
+		});
+
+		it('keeps a markdown heading in content instead of silently dropping it', async () => {
+			await storageManager.saveNote({ ...testNote, content: '## Heading\nbody text' });
+			const loaded = await storageManager.loadNoteById(testNote.id);
+
+			expect(loaded!.content).toBe('## Heading\nbody text');
+		});
+	});
 });

--- a/packages/code-notes-core/test/storageManager.test.ts
+++ b/packages/code-notes-core/test/storageManager.test.ts
@@ -475,6 +475,16 @@ Hi.
 		expect(errors[0].file).toBe('bad.md');
 	});
 
+	it('round-trips approvedBy through markdown', async () => {
+		// The serializer writes an explicit field list, so an unlisted field is
+		// silently dropped on save — this is the only thing proving it isn't.
+		await storageManager.saveNote({ ...testNote, authorType: 'agent', approvedBy: 'Jane Dev' });
+		const loaded = await storageManager.loadNoteById(testNote.id);
+
+		expect(loaded!.approvedBy).toBe('Jane Dev');
+		expect(loaded!.authorType).toBe('agent');
+	});
+
 	// Note content is agent-controlled input crossing a human review boundary.
 	// The metadata branches match on prefix, so content had to stop being
 	// re-parsed as metadata on reload.

--- a/packages/code-notes-core/test/workspaceConfig.test.ts
+++ b/packages/code-notes-core/test/workspaceConfig.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import { readWorkspaceConfig, writeWorkspaceConfig, DEFAULT_WORKSPACE_CONFIG } from '../src/workspaceConfig.js';
+
+describe('workspaceConfig', () => {
+  let storagePath: string;
+
+  beforeEach(async () => {
+    storagePath = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-config-test-'));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(storagePath, { recursive: true, force: true });
+  });
+
+  it('defaults to audit mode when no config file exists', async () => {
+    const config = await readWorkspaceConfig(storagePath);
+    expect(config).toEqual(DEFAULT_WORKSPACE_CONFIG);
+    expect(config.agentWriteMode).toBe('audit');
+  });
+
+  it('round-trips a written config', async () => {
+    await writeWorkspaceConfig(storagePath, {
+      agentWriteMode: 'queue',
+      agentAllowList: ['claude-code'],
+      auditLogRetention: 500,
+    });
+    const config = await readWorkspaceConfig(storagePath);
+    expect(config.agentWriteMode).toBe('queue');
+    expect(config.agentAllowList).toEqual(['claude-code']);
+    expect(config.auditLogRetention).toBe(500);
+  });
+
+  it('falls back to defaults on malformed JSON rather than throwing', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await fs.writeFile(path.join(storagePath, 'config.json'), '{ not json');
+    const config = await readWorkspaceConfig(storagePath);
+    expect(config).toEqual(DEFAULT_WORKSPACE_CONFIG);
+  });
+
+  it('falls back to the default mode for an unrecognized mode value, keeping valid siblings', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await fs.writeFile(
+      path.join(storagePath, 'config.json'),
+      JSON.stringify({ agentWriteMode: 'yolo', auditLogRetention: 42 }),
+    );
+    const config = await readWorkspaceConfig(storagePath);
+    expect(config.agentWriteMode).toBe('audit');
+    expect(config.auditLogRetention).toBe(42);
+  });
+
+  it('rejects a non-string allow-list rather than handing on a lying string[]', async () => {
+    await fs.writeFile(
+      path.join(storagePath, 'config.json'),
+      JSON.stringify({ agentAllowList: [1, {}, 'claude-code'] }),
+    );
+    const config = await readWorkspaceConfig(storagePath);
+    expect(config.agentAllowList).toEqual([]);
+  });
+
+  // NaN/Infinity aren't JSON literals, so they can't reach the guard through a
+  // config file — only these two can.
+  it.each([['zero', 0], ['negative', -5]])(
+    'falls back to the default retention for %s, which would rotate the log on every append',
+    async (_label, value) => {
+      await fs.writeFile(
+        path.join(storagePath, 'config.json'),
+        JSON.stringify({ auditLogRetention: value }),
+      );
+      const config = await readWorkspaceConfig(storagePath);
+      expect(config.auditLogRetention).toBe(DEFAULT_WORKSPACE_CONFIG.auditLogRetention);
+    },
+  );
+});

--- a/packages/code-notes-mcp/README.md
+++ b/packages/code-notes-mcp/README.md
@@ -70,14 +70,40 @@ Every tool returns its result as text content whose body is JSON — a note obje
 
 ## Trust model
 
-The server operates in `direct` mode, and that is currently the only behavior: starting it with `--agent <name>` authorizes writes, and an authorized agent's notes land immediately with no review step and no further gating. Without `--agent`, only the read tools are exposed.
+Agent writes are governed by `agentWriteMode` in `<storageDir>/config.json` — a workspace-owned file, not a server flag. There is deliberately no `--write-mode` option: an agent that picks its own mode has no rails.
 
-There is no audit trail or approval queue yet — v0.5 adds the trust model (`audit` / `queue` / `direct` modes) for reviewing agent-authored notes before they land. Until then, treat write access the way you'd treat handing an agent your editor: grant it to agents you'd let write files directly, and expect their notes to appear immediately for everyone sharing the workspace.
+| Mode | Agent writes | Use when |
+|---|---|---|
+| `direct` | Land immediately, attributed `authorType: agent`. | Solo dev, trusted agent. |
+| `audit` (default) | Land immediately, and every op is appended to `<storageDir>/_audit.log`. The extension's **Agent activity** view lists them with a Revert action. | Most teams. |
+| `queue` | Do **not** touch live notes. Each write becomes a proposal in `<storageDir>/_pending/`, surfaced in the extension's **Pending agent proposals** view for Approve / Reject. | Shared or regulated codebases. |
+
+```jsonc
+// .code-notes/config.json
+{
+  "agentWriteMode": "audit",   // "direct" | "audit" | "queue"
+  "agentAllowList": [],         // informational; empty allows any --agent name
+  "auditLogRetention": 1000     // ops kept before rotating to _audit.log.1
+}
+```
+
+Without `--agent`, the server is read-only and none of this applies.
+
+### What write tools return in `queue` mode
+
+Not a note, and **not an error** — retrying will not help:
+
+```json
+{ "status": "pending", "proposalId": "prop-xyz", "message": "Awaiting human approval." }
+```
+
+The mode is re-read from disk on every call, so a human changing it takes effect immediately — no server restart.
 
 ## Troubleshooting
 
 - **`{ "error": "lock_timeout", "retryable": true }`** — another writer (the VS Code extension, or a second agent) held the note's lock. Retry the same call once after a short delay; if it times out again, treat it as a real conflict rather than looping.
 - **No notes / empty results, and no `.code-notes/` in the workspace** — the server starts in empty mode when the workspace has no notes yet and creates `.code-notes/` on first write. Pass `--require-existing` if you want startup to fail (exit 3) instead.
+- **Write tools return `{ "status": "pending" }` instead of a note** — the workspace is in `queue` mode. This is not a failure and retrying won't change it: a human approves the proposal in the extension's **Pending agent proposals** view. Check `agentWriteMode` in `<storageDir>/config.json`.
 - **The agent sees no notes, or writes land somewhere the extension never shows** — the server defaults to `.code-notes/`, but the extension's `codeContextNotes.storageDirectory` setting can point elsewhere. If you changed it, pass the same value as `--storage-dir <name>`; otherwise the two sides read different directories and take their locks in different places, so their writes are no longer serialized against each other.
 - **Version mismatch with the extension** — the MCP server and the VS Code extension share the on-disk note format via `@jnahian/code-notes-core`. Keep them on compatible versions; a note written by a newer format may not round-trip through an older reader.
 

--- a/packages/code-notes-mcp/package.json
+++ b/packages/code-notes-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jnahian/code-notes-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server for Code Context Notes — gives coding agents read/write access to workspace notes.",
   "license": "MIT",
   "type": "module",
@@ -20,7 +20,7 @@
     "test:unit": "vitest run"
   },
   "dependencies": {
-    "@jnahian/code-notes-core": "0.1.0",
+    "@jnahian/code-notes-core": "0.2.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "diff": "^5.2.0",
     "zod": "^4.4.3"

--- a/packages/code-notes-mcp/src/server.ts
+++ b/packages/code-notes-mcp/src/server.ts
@@ -191,6 +191,9 @@ export async function startServer(args: StartArgs): Promise<void> {
     // long-lived server runs, and a cached policy is a policy that lies.
     agentWriteMode: async () => (await readWorkspaceConfig(storagePath)).agentWriteMode,
     agentName: args.agent ?? 'unknown-agent',
+    // This server is the agent: every write it makes is an agent write,
+    // whatever note it targets.
+    agentWriter: true,
   });
 
   const readOnly = !args.agent;

--- a/packages/code-notes-mcp/src/server.ts
+++ b/packages/code-notes-mcp/src/server.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import * as fs from 'fs/promises';
 import {
   StorageManager, NoteManager, LockManager, ContentHashTracker, AuthorProvider,
+  AuditLog, ProposalStore, PendingWriteError, readWorkspaceConfig,
 } from '@jnahian/code-notes-core';
 import { getNoteToolDef, getNoteInput, getNote } from './tools/get_note.js';
 import { getNotesForFileToolDef, getNotesForFileInput, getNotesForFile } from './tools/get_notes_for_file.js';
@@ -18,7 +19,7 @@ import { editNoteToolDef, editNoteInput, editNote } from './tools/edit_note.js';
 import { deleteNoteToolDef, deleteNoteInput, deleteNote } from './tools/delete_note.js';
 import { addHandoffToolDef, addHandoffInput, addHandoff } from './tools/add_handoff.js';
 import { addDecisionToolDef, addDecisionInput, addDecision } from './tools/add_decision.js';
-import { errorResult } from './tools/errors.js';
+import { errorResult, pendingResult } from './tools/errors.js';
 import { digestResourceDef, readDigest } from './resources/digest.js';
 import { indexResourceDef, readIndex } from './resources/indexResource.js';
 import { FILE_RESOURCE_URI_PREFIX, readFileResource } from './resources/file.js';
@@ -84,6 +85,9 @@ export async function handleToolCall(
   try {
     return await dispatchToolCall(name, args, deps);
   } catch (e) {
+    // Queue mode diverted the write to a proposal — the expected outcome in
+    // that mode, not a failure.
+    if (e instanceof PendingWriteError) return pendingResult(e.proposalId);
     // Last-resort guard: anything a tool still throws (e.g. an unexpected
     // failure after a note was already created) becomes an in-band error, so
     // tool failures are never surfaced as JSON-RPC protocol errors.
@@ -173,7 +177,21 @@ export async function startServer(args: StartArgs): Promise<void> {
     getAuthorName: async () => args.agent ?? 'unknown-agent',
     updateConfigOverride: () => {},
   };
-  const noteManager = new NoteManager(storage, hashTracker, authorProvider, { lockManager });
+  const storagePath = path.join(workspace, storageDir);
+  const auditLog = new AuditLog(path.join(storagePath, '_audit.log'), {
+    lockManager,
+    retention: (await readWorkspaceConfig(storagePath)).auditLogRetention,
+  });
+  const proposalStore = new ProposalStore(path.join(storagePath, '_pending'));
+  const noteManager = new NoteManager(storage, hashTracker, authorProvider, {
+    lockManager,
+    auditLog,
+    proposalStore,
+    // Re-read per call, never captured: a human can change the mode while this
+    // long-lived server runs, and a cached policy is a policy that lies.
+    agentWriteMode: async () => (await readWorkspaceConfig(storagePath)).agentWriteMode,
+    agentName: args.agent ?? 'unknown-agent',
+  });
 
   const readOnly = !args.agent;
   const server = new Server(

--- a/packages/code-notes-mcp/src/tools/create_note.ts
+++ b/packages/code-notes-mcp/src/tools/create_note.ts
@@ -73,12 +73,23 @@ export async function createNote(
     return errorResult('file_not_found', { file: args.file });
   }
 
-  let note;
   try {
-    note = await deps.noteManager.createNote(
-      { filePath: absFile, lineRange: args.lineRange, content: args.content },
+    const note = await deps.noteManager.createNote(
+      {
+        filePath: absFile,
+        lineRange: args.lineRange,
+        content: args.content,
+        authorType: 'agent',
+        ...(args.type !== undefined && { type: args.type }),
+        ...(args.tags !== undefined && { tags: args.tags }),
+        ...(args.scope !== undefined && { scope: args.scope }),
+        ...(args.references !== undefined && { references: args.references }),
+        ...(args.priority !== undefined && { priority: args.priority }),
+        ...(args.expiresAt !== undefined && { expiresAt: args.expiresAt }),
+      },
       doc,
     );
+    return { content: [{ type: 'text' as const, text: JSON.stringify(note, null, 2) }] };
   } catch (e) {
     if (isLockTimeout(e)) return errorResult('lock_timeout', { retryable: true });
     // Core's range validation errors all start with "Line range"; anything
@@ -86,29 +97,5 @@ export async function createNote(
     const msg = (e as Error).message ?? String(e);
     if (msg.includes('Line range')) return errorResult('invalid_line_range', { detail: msg });
     return errorResult('internal_error', { detail: msg });
-  }
-
-  const fields: {
-    authorType: 'agent';
-    type?: NoteType;
-    tags?: string[];
-    scope?: NoteScope;
-    references?: NoteReference[];
-    priority?: NotePriority;
-    expiresAt?: string;
-  } = { authorType: 'agent' };
-  if (args.type !== undefined) fields.type = args.type;
-  if (args.tags !== undefined) fields.tags = args.tags;
-  if (args.scope !== undefined) fields.scope = args.scope;
-  if (args.references !== undefined) fields.references = args.references;
-  if (args.priority !== undefined) fields.priority = args.priority;
-  if (args.expiresAt !== undefined) fields.expiresAt = args.expiresAt;
-
-  try {
-    const final = await deps.noteManager.updateNoteMetadata(note.id, fields);
-    return { content: [{ type: 'text' as const, text: JSON.stringify(final, null, 2) }] };
-  } catch (e) {
-    if (isLockTimeout(e)) return errorResult('lock_timeout', { retryable: true });
-    throw e;
   }
 }

--- a/packages/code-notes-mcp/src/tools/create_note.ts
+++ b/packages/code-notes-mcp/src/tools/create_note.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import * as path from 'path';
 import type { NoteManager, NoteType, NoteScope, NotePriority, NoteReference } from '@jnahian/code-notes-core';
+import { PendingWriteError } from '@jnahian/code-notes-core';
 import { buildDocumentFromFile } from '../fileDocument.js';
 import { errorResult, isLockTimeout } from './errors.js';
 
@@ -91,6 +92,11 @@ export async function createNote(
     );
     return { content: [{ type: 'text' as const, text: JSON.stringify(note, null, 2) }] };
   } catch (e) {
+    // Queue mode diverting this write is not a failure — let it reach the
+    // dispatcher, which turns it into the pending result. This catch is the
+    // only one that swallows unknown errors, so without this the agent would
+    // be told its write crashed while the proposal quietly landed.
+    if (e instanceof PendingWriteError) throw e;
     if (isLockTimeout(e)) return errorResult('lock_timeout', { retryable: true });
     // Core's range validation errors all start with "Line range"; anything
     // else is an unexpected failure and must not masquerade as a range error.

--- a/packages/code-notes-mcp/src/tools/errors.ts
+++ b/packages/code-notes-mcp/src/tools/errors.ts
@@ -5,3 +5,16 @@ export function errorResult(error: string, extra?: Record<string, unknown>) {
 export function isLockTimeout(e: unknown): boolean {
   return e instanceof Error && e.message.includes('lock_timeout');
 }
+
+/**
+ * Queue mode's success shape. Deliberately not an `error`: an agent that saw
+ * an error code here would retry-loop against a human approval step.
+ */
+export function pendingResult(proposalId: string) {
+  return {
+    content: [{
+      type: 'text' as const,
+      text: JSON.stringify({ status: 'pending', proposalId, message: 'Awaiting human approval.' }),
+    }],
+  };
+}

--- a/packages/code-notes-mcp/test/queue_mode.test.ts
+++ b/packages/code-notes-mcp/test/queue_mode.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import {
+  StorageManager, NoteManager, ContentHashTracker, ProposalStore, writeWorkspaceConfig,
+} from '@jnahian/code-notes-core';
+import { handleToolCall } from '../src/server.js';
+
+describe('queue mode via the MCP dispatch', () => {
+  let tempDir: string;
+  let noteManager: NoteManager;
+  let store: ProposalStore;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'queue-mode-test-'));
+    const storagePath = path.join(tempDir, '.code-notes');
+    await writeWorkspaceConfig(storagePath, {
+      agentWriteMode: 'queue',
+      agentAllowList: [],
+      auditLogRetention: 1000,
+    });
+    store = new ProposalStore(path.join(storagePath, '_pending'));
+    noteManager = new NoteManager(
+      new StorageManager(tempDir, '.code-notes'),
+      new ContentHashTracker(),
+      { getAuthorName: async () => 'claude-code', updateConfigOverride: () => {} },
+      {
+        proposalStore: store,
+        agentWriteMode: async () => 'queue',
+        agentName: 'claude-code',
+      },
+    );
+    await fs.writeFile(path.join(tempDir, 'app.ts'), 'line0\n');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns the pending shape instead of a note, and writes a proposal', async () => {
+    const r = await handleToolCall(
+      'create_note',
+      { file: 'app.ts', lineRange: { start: 0, end: 0 }, content: 'proposed' },
+      { noteManager, workspace: tempDir, readOnly: false },
+    );
+    const parsed = JSON.parse(r.content[0].text);
+
+    expect(parsed.status).toBe('pending');
+    expect(parsed.proposalId).toMatch(/^prop-/);
+    expect(parsed.message).toContain('approval');
+    // Not an error — agents must not treat this as retryable.
+    expect(parsed.error).toBeUndefined();
+
+    expect(await store.list()).toHaveLength(1);
+    expect(await noteManager.getAllNotes()).toHaveLength(0);
+  });
+
+  it('reports pending for add_handoff too, which funnels through create', async () => {
+    const r = await handleToolCall(
+      'add_handoff',
+      { file: 'app.ts', lineRange: { start: 0, end: 0 }, content: 'pick up here' },
+      { noteManager, workspace: tempDir, readOnly: false },
+    );
+    const parsed = JSON.parse(r.content[0].text);
+
+    expect(parsed.status).toBe('pending');
+    expect(await noteManager.getAllNotes()).toHaveLength(0);
+  });
+});

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -422,6 +422,28 @@
           "default": ".code-notes",
           "description": "Directory where notes are stored (relative to workspace root)"
         },
+        "codeContextNotes.agentWriteMode": {
+          "type": "string",
+          "enum": ["direct", "audit", "queue"],
+          "enumDescriptions": [
+            "Agent writes land immediately.",
+            "Agent writes land and are logged to .code-notes/_audit.log, reviewable in the Agent activity view.",
+            "Agent writes become proposals needing approval in the Pending agent proposals view."
+          ],
+          "default": "audit",
+          "description": "How writes from MCP agents are handled. Written to .code-notes/config.json so the standalone MCP server reads the same policy."
+        },
+        "codeContextNotes.agentAllowList": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Agent names allowed to write (matches the server's --agent value). Empty allows any. Informational, not a security boundary."
+        },
+        "codeContextNotes.auditLogRetention": {
+          "type": "number",
+          "default": 1000,
+          "description": "Number of audit log entries kept before older ones rotate to _audit.log.1."
+        },
         "codeContextNotes.authorName": {
           "type": "string",
           "default": "",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
   "name": "code-context-notes",
   "displayName": "Code Context Notes - Smart Annotations",
   "description": "Add contextual notes to your code with full version history and intelligent tracking",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "publisher": "jnahian",
   "icon": "images/icon.png",
   "galleryBanner": {
@@ -488,7 +488,11 @@
         },
         "codeContextNotes.agentWriteMode": {
           "type": "string",
-          "enum": ["direct", "audit", "queue"],
+          "enum": [
+            "direct",
+            "audit",
+            "queue"
+          ],
           "enumDescriptions": [
             "Agent writes land immediately.",
             "Agent writes land and are logged to .code-notes/_audit.log, reviewable in the Agent activity view.",
@@ -499,7 +503,9 @@
         },
         "codeContextNotes.agentAllowList": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "default": [],
           "description": "Agent names allowed to write (matches the server's --agent value). Empty allows any. Informational, not a security boundary."
         },
@@ -597,7 +603,7 @@
     "url": "https://github.com/jnahian/code-context-notes"
   },
   "dependencies": {
-    "@jnahian/code-notes-core": "0.1.0",
+    "@jnahian/code-notes-core": "0.2.0",
     "uuid": "^14.0.0"
   }
 }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -234,6 +234,24 @@
         "command": "codeContextNotes.openAuditedNote",
         "title": "Open the note this entry refers to",
         "category": "Code Notes"
+      },
+      {
+        "command": "codeContextNotes.approveProposal",
+        "title": "Approve",
+        "icon": "$(check)",
+        "category": "Code Notes"
+      },
+      {
+        "command": "codeContextNotes.rejectProposal",
+        "title": "Reject",
+        "icon": "$(x)",
+        "category": "Code Notes"
+      },
+      {
+        "command": "codeContextNotes.editAndApproveProposal",
+        "title": "Edit and approve",
+        "icon": "$(edit)",
+        "category": "Code Notes"
       }
     ],
     "keybindings": [
@@ -327,6 +345,21 @@
           "command": "codeContextNotes.revertAgentOp",
           "when": "view == codeContextNotes.agentActivityView && viewItem == agentActivityItem",
           "group": "inline"
+        },
+        {
+          "command": "codeContextNotes.approveProposal",
+          "when": "view == codeContextNotes.pendingProposalsView && viewItem == proposalItem",
+          "group": "inline@1"
+        },
+        {
+          "command": "codeContextNotes.editAndApproveProposal",
+          "when": "view == codeContextNotes.pendingProposalsView && viewItem == proposalItem",
+          "group": "inline@2"
+        },
+        {
+          "command": "codeContextNotes.rejectProposal",
+          "when": "view == codeContextNotes.pendingProposalsView",
+          "group": "inline@3"
         },
         {
           "command": "codeContextNotes.openNoteFromSidebar",
@@ -430,6 +463,11 @@
         {
           "id": "codeContextNotes.agentActivityView",
           "name": "Agent activity",
+          "contextualTitle": "Code Context Notes"
+        },
+        {
+          "id": "codeContextNotes.pendingProposalsView",
+          "name": "Pending agent proposals",
           "contextualTitle": "Code Context Notes"
         }
       ]

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -218,6 +218,22 @@
         "command": "codeContextNotes.setNoteMetadata",
         "title": "Set Note Type / Tags / Priority…",
         "category": "Code Notes"
+      },
+      {
+        "command": "codeContextNotes.revertAgentOp",
+        "title": "Revert this agent change",
+        "icon": "$(discard)",
+        "category": "Code Notes"
+      },
+      {
+        "command": "codeContextNotes.truncateAuditLog",
+        "title": "Truncate Audit Log",
+        "category": "Code Notes"
+      },
+      {
+        "command": "codeContextNotes.openAuditedNote",
+        "title": "Open the note this entry refers to",
+        "category": "Code Notes"
       }
     ],
     "keybindings": [
@@ -307,6 +323,11 @@
         }
       ],
       "view/item/context": [
+        {
+          "command": "codeContextNotes.revertAgentOp",
+          "when": "view == codeContextNotes.agentActivityView && viewItem == agentActivityItem",
+          "group": "inline"
+        },
         {
           "command": "codeContextNotes.openNoteFromSidebar",
           "when": "view == codeContextNotes.sidebarView && viewItem == noteNode",
@@ -404,6 +425,11 @@
         {
           "id": "codeContextNotes.sidebarView",
           "name": "Notes",
+          "contextualTitle": "Code Context Notes"
+        },
+        {
+          "id": "codeContextNotes.agentActivityView",
+          "name": "Agent activity",
           "contextualTitle": "Code Context Notes"
         }
       ]

--- a/packages/extension/src/agentActivityProvider.ts
+++ b/packages/extension/src/agentActivityProvider.ts
@@ -1,0 +1,42 @@
+import * as vscode from 'vscode';
+import type { AuditEntry, AuditLog } from '@jnahian/code-notes-core';
+
+const DISPLAY_LIMIT = 50;
+
+export class AgentActivityItem extends vscode.TreeItem {
+	constructor(public readonly entry: AuditEntry) {
+		super(`${entry.op} · ${vscode.workspace.asRelativePath(entry.file)}`, vscode.TreeItemCollapsibleState.None);
+		this.description = `${entry.agent} · ${new Date(entry.ts).toLocaleString()}`;
+		this.tooltip = `${entry.op} ${entry.noteId}\nby ${entry.agent}\n${entry.ts}`;
+		this.contextValue = 'agentActivityItem';
+		this.iconPath = new vscode.ThemeIcon(
+			entry.op === 'create' ? 'add' : entry.op === 'edit' ? 'edit' : 'trash',
+		);
+		this.command = {
+			command: 'codeContextNotes.openAuditedNote',
+			title: 'Open note',
+			arguments: [entry],
+		};
+	}
+}
+
+/** Read-only view over the audit log; the log on disk is the source of truth. */
+export class AgentActivityProvider implements vscode.TreeDataProvider<AgentActivityItem> {
+	private _onDidChangeTreeData = new vscode.EventEmitter<AgentActivityItem | undefined | null | void>();
+	readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+	constructor(private auditLog: AuditLog) {}
+
+	refresh(): void {
+		this._onDidChangeTreeData.fire();
+	}
+
+	getTreeItem(element: AgentActivityItem): vscode.TreeItem {
+		return element;
+	}
+
+	async getChildren(): Promise<AgentActivityItem[]> {
+		const entries = await this.auditLog.read(DISPLAY_LIMIT);
+		return entries.map(e => new AgentActivityItem(e));
+	}
+}

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -469,10 +469,15 @@ function registerAllCommands(context: vscode.ExtensionContext) {
 					// soft-delete, so undeleteNote brings it back as it was.
 					await noteManager.undeleteNote(note.id);
 				} else {
-					// The reverse of an edit is the previous content. history is
-					// append-only, so the entry before the last is the state this
-					// edit replaced.
-					const prior = note.history[note.history.length - 2];
+					// The reverse of an edit is the content this edit replaced. Find
+					// it by prevContentHash rather than by position: the clicked entry
+					// may not be the note's latest change (a later agent or human edit
+					// could have landed on top), and history[length - 2] would then
+					// restore the wrong version — including re-applying the agent's own
+					// content if a human edited after it.
+					const prior = entry.prevContentHash
+						? note.history.find(h => hashNoteContent(h.content) === entry.prevContentHash)
+						: undefined;
 					if (!prior) {
 						vscode.window.showWarningMessage('No prior version recorded for this note.');
 						return;

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -4,9 +4,10 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { StorageManager, ExportWriter, ContentHashTracker, NoteManager, SearchManager, LockManager, writeWorkspaceConfig, AuditLog } from '@jnahian/code-notes-core';
-import type { AuditEntry } from '@jnahian/code-notes-core';
+import { StorageManager, ExportWriter, ContentHashTracker, NoteManager, SearchManager, LockManager, writeWorkspaceConfig, AuditLog, ProposalStore, hashNoteContent } from '@jnahian/code-notes-core';
+import type { AuditEntry, Proposal } from '@jnahian/code-notes-core';
 import { AgentActivityProvider, AgentActivityItem } from './agentActivityProvider.js';
+import { PendingProposalsProvider, ProposalItem } from './pendingProposalsProvider.js';
 import { GitIntegration } from './gitIntegration.js';
 import { CommentController } from './commentController.js';
 import { CodeNotesLensProvider } from './codeLensProvider.js';
@@ -18,6 +19,8 @@ let noteManager: NoteManager;
 // rather than capturing it.
 let auditLog: AuditLog | undefined;
 let agentActivityProvider: AgentActivityProvider | undefined;
+let proposalStore: ProposalStore | undefined;
+let pendingProposalsProvider: PendingProposalsProvider | undefined;
 let exportWriter: ExportWriter;
 let searchManager: SearchManager;
 let commentController: CommentController;
@@ -96,6 +99,29 @@ export async function activate(context: vscode.ExtensionContext) {
 				// what they asked for.
 				await syncWorkspaceConfig();
 			}
+
+			// Leaving queue mode strands anything still pending — those writes
+			// were never applied, and silently abandoning them would lose an
+			// agent's work without anyone deciding to.
+			if (e.affectsConfiguration('codeContextNotes.agentWriteMode') && proposalStore) {
+				const mode = vscode.workspace.getConfiguration('codeContextNotes').get<string>('agentWriteMode');
+				const stranded = await proposalStore.list();
+				if (mode !== 'queue' && stranded.length > 0) {
+					const pick = await vscode.window.showWarningMessage(
+						`${stranded.length} agent proposal(s) are still pending, but queue mode is off.`,
+						'Review them',
+						'Reject all',
+					);
+					if (pick === 'Review them') {
+						await vscode.commands.executeCommand('codeContextNotes.pendingProposalsView.focus');
+					} else if (pick === 'Reject all') {
+						for (const p of stranded) {
+							await proposalStore.reject(p.proposalId);
+						}
+						pendingProposalsProvider?.refresh();
+					}
+				}
+			}
 		}),
 	);
 
@@ -132,6 +158,18 @@ export async function activate(context: vscode.ExtensionContext) {
 	);
 	// The watcher emits this when the MCP server appends from another process.
 	noteManager.on('auditLogChanged', () => agentActivityProvider?.refresh());
+
+	// Pending proposals (queue mode): the review queue for agent writes.
+	proposalStore = new ProposalStore(path.join(storagePath, '_pending'));
+	// A proposal is orphaned when the note it targets is gone — approving it
+	// would have nothing to apply to.
+	const isOrphaned = async (p: Proposal): Promise<boolean> =>
+		p.op !== 'create' && !(await noteManager.getNoteByIdGlobal(p.targetNoteId!));
+	pendingProposalsProvider = new PendingProposalsProvider(proposalStore, isOrphaned);
+	context.subscriptions.push(
+		vscode.window.registerTreeDataProvider('codeContextNotes.pendingProposalsView', pendingProposalsProvider),
+	);
+	noteManager.on('proposalsChanged', () => pendingProposalsProvider?.refresh());
 
 	// Initialize search manager
 	searchManager = new SearchManager(context.globalState);
@@ -291,6 +329,68 @@ const x = 1;
  * Note: Commands are registered even without a workspace, but many will show
  * error messages if workspace-dependent features (noteManager, commentController) are not initialized
  */
+/**
+ * Apply an approved proposal as if the approver wrote it. The approver's name
+ * goes on the note and in approvedBy; authorType stays 'agent' because an
+ * agent did compose it — approval is accountability, not authorship laundering.
+ *
+ * noteManager here is the extension's (agentWriter false), so applying is a
+ * human write: it is not re-diverted into another proposal.
+ */
+async function applyProposal(p: Proposal, content: string): Promise<void> {
+	if (!noteManager || !proposalStore) {
+		throw new Error('Code Context Notes requires a workspace folder to be opened.');
+	}
+	const approver = await noteManager.getDefaultAuthor();
+	const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(p.file));
+
+	if (p.op === 'create') {
+		await noteManager.createNote({
+			filePath: p.file,
+			lineRange: p.lineRange!,
+			content,
+			author: approver,
+			authorType: 'agent',
+			approvedBy: approver,
+		}, doc);
+	} else if (p.op === 'edit') {
+		await noteManager.updateNote({ id: p.targetNoteId!, content, author: approver }, doc);
+	} else {
+		await noteManager.deleteNote(p.targetNoteId!, p.file);
+	}
+
+	await proposalStore.remove(p.proposalId);
+	pendingProposalsProvider?.refresh();
+}
+
+/**
+ * Simple-pick, not a 3-way merge (spec §7.6): if the note changed after the
+ * agent proposed its edit, the human picks a side. Returns the content to
+ * apply, or undefined to abandon. Add a real merge only if conflicts turn out
+ * to be common.
+ */
+async function resolveStaleTarget(p: Proposal): Promise<string | undefined> {
+	if (p.op === 'create' || !p.targetContentHash || !noteManager) {
+		return p.content;
+	}
+	const current = await noteManager.getNoteByIdGlobal(p.targetNoteId!);
+	if (!current) {
+		vscode.window.showWarningMessage('The note this proposal targets no longer exists. Reject it instead.');
+		return undefined;
+	}
+	if (hashNoteContent(current.content) === p.targetContentHash) {
+		return p.content;
+	}
+
+	const pick = await vscode.window.showWarningMessage(
+		'This note changed after the agent proposed its edit.',
+		{ modal: true, detail: `Yours:\n${current.content}\n\nAgent's:\n${p.content}` },
+		"Use agent's version",
+		'Keep mine',
+	);
+	return pick === "Use agent's version" ? p.content : undefined;
+}
+
 function registerAllCommands(context: vscode.ExtensionContext) {
 	// --- Agent activity (audit mode) ---
 
@@ -374,6 +474,53 @@ function registerAllCommands(context: vscode.ExtensionContext) {
 				vscode.window.showInformationMessage(`Reverted ${entry.op} on ${path.basename(note.filePath)}.`);
 			} catch (e) {
 				vscode.window.showErrorMessage(`Revert failed: ${(e as Error).message}`);
+			}
+		}),
+	);
+
+	// --- Pending agent proposals (queue mode) ---
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('codeContextNotes.rejectProposal', async (item: ProposalItem) => {
+			if (!proposalStore) {
+				vscode.window.showErrorMessage('Code Context Notes requires a workspace folder to be opened.');
+				return;
+			}
+			await proposalStore.reject(item.proposal.proposalId);
+			pendingProposalsProvider?.refresh();
+			vscode.window.showInformationMessage('Proposal rejected. Kept in _pending/.rejected/ for audit.');
+		}),
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('codeContextNotes.approveProposal', async (item: ProposalItem) => {
+			try {
+				const content = await resolveStaleTarget(item.proposal);
+				if (content === undefined) {
+					return;
+				}
+				await applyProposal(item.proposal, content);
+				vscode.window.showInformationMessage('Proposal approved.');
+			} catch (e) {
+				vscode.window.showErrorMessage(`Approve failed: ${(e as Error).message}`);
+			}
+		}),
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('codeContextNotes.editAndApproveProposal', async (item: ProposalItem) => {
+			const edited = await vscode.window.showInputBox({
+				prompt: 'Edit the proposed note before approving',
+				value: item.proposal.content,
+			});
+			if (edited === undefined) {
+				return;
+			}
+			try {
+				await applyProposal(item.proposal, edited);
+				vscode.window.showInformationMessage('Proposal approved with your edits.');
+			} catch (e) {
+				vscode.window.showErrorMessage(`Approve failed: ${(e as Error).message}`);
 			}
 		}),
 	);

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -400,7 +400,9 @@ function registerAllCommands(context: vscode.ExtensionContext) {
 				vscode.window.showErrorMessage('Code Context Notes requires a workspace folder to be opened.');
 				return;
 			}
-			const note = await noteManager.getNoteByIdGlobal(entry.noteId);
+			// Include deleted: a delete audit entry points at a soft-deleted
+			// note, and you still want to jump to where it was.
+			const note = await noteManager.getNoteByIdIncludingDeleted(entry.noteId);
 			if (!note) {
 				vscode.window.showWarningMessage(`Note ${entry.noteId} no longer exists.`);
 				return;
@@ -439,7 +441,9 @@ function registerAllCommands(context: vscode.ExtensionContext) {
 				return;
 			}
 			const { entry } = item;
-			const note = await noteManager.getNoteByIdGlobal(entry.noteId);
+			// Include deleted: a delete entry is precisely the case where the
+			// note is soft-deleted, and it's what Revert must restore.
+			const note = await noteManager.getNoteByIdIncludingDeleted(entry.noteId);
 			if (!note) {
 				vscode.window.showWarningMessage(`Note ${entry.noteId} no longer exists — nothing to revert.`);
 				return;
@@ -458,10 +462,14 @@ function registerAllCommands(context: vscode.ExtensionContext) {
 				if (entry.op === 'create') {
 					// The reverse of a create is a delete.
 					await noteManager.deleteNote(note.id, note.filePath);
+				} else if (entry.op === 'delete') {
+					// The reverse of a delete is a restore. The content survived the
+					// soft-delete, so undeleteNote brings it back as it was.
+					await noteManager.undeleteNote(note.id);
 				} else {
-					// The reverse of an edit/delete is the previous content. history
-					// is append-only, so the entry before the last is the state this
-					// op replaced.
+					// The reverse of an edit is the previous content. history is
+					// append-only, so the entry before the last is the state this
+					// edit replaced.
 					const prior = note.history[note.history.length - 2];
 					if (!prior) {
 						vscode.window.showWarningMessage('No prior version recorded for this note.');

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -354,7 +354,7 @@ async function applyProposal(p: Proposal, content: string): Promise<void> {
 			approvedBy: approver,
 		}, doc);
 	} else if (p.op === 'edit') {
-		await noteManager.updateNote({ id: p.targetNoteId!, content, author: approver }, doc);
+		await noteManager.updateNote({ id: p.targetNoteId!, content, author: approver, approvedBy: approver }, doc);
 	} else {
 		await noteManager.deleteNote(p.targetNoteId!, p.file);
 	}

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -4,13 +4,20 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { StorageManager, ExportWriter, ContentHashTracker, NoteManager, SearchManager, LockManager, writeWorkspaceConfig } from '@jnahian/code-notes-core';
+import { StorageManager, ExportWriter, ContentHashTracker, NoteManager, SearchManager, LockManager, writeWorkspaceConfig, AuditLog } from '@jnahian/code-notes-core';
+import type { AuditEntry } from '@jnahian/code-notes-core';
+import { AgentActivityProvider, AgentActivityItem } from './agentActivityProvider.js';
 import { GitIntegration } from './gitIntegration.js';
 import { CommentController } from './commentController.js';
 import { CodeNotesLensProvider } from './codeLensProvider.js';
 import { NotesSidebarProvider } from './notesSidebarProvider.js';
 
 let noteManager: NoteManager;
+// Module-scoped like noteManager: registerAllCommands runs on both the
+// workspace and no-workspace paths, so its handlers guard on this being set
+// rather than capturing it.
+let auditLog: AuditLog | undefined;
+let agentActivityProvider: AgentActivityProvider | undefined;
 let exportWriter: ExportWriter;
 let searchManager: SearchManager;
 let commentController: CommentController;
@@ -113,6 +120,18 @@ export async function activate(context: vscode.ExtensionContext) {
 	if ((await storage.getAllNoteFiles()).length > 0) {
 		await syncWorkspaceConfig();
 	}
+
+	// Agent activity: a read-only view over the audit log the MCP server writes.
+	auditLog = new AuditLog(path.join(storagePath, '_audit.log'), {
+		lockManager,
+		retention: config.get<number>('auditLogRetention', 1000),
+	});
+	agentActivityProvider = new AgentActivityProvider(auditLog);
+	context.subscriptions.push(
+		vscode.window.registerTreeDataProvider('codeContextNotes.agentActivityView', agentActivityProvider),
+	);
+	// The watcher emits this when the MCP server appends from another process.
+	noteManager.on('auditLogChanged', () => agentActivityProvider?.refresh());
 
 	// Initialize search manager
 	searchManager = new SearchManager(context.globalState);
@@ -273,6 +292,92 @@ const x = 1;
  * error messages if workspace-dependent features (noteManager, commentController) are not initialized
  */
 function registerAllCommands(context: vscode.ExtensionContext) {
+	// --- Agent activity (audit mode) ---
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('codeContextNotes.openAuditedNote', async (entry: AuditEntry) => {
+			if (!noteManager) {
+				vscode.window.showErrorMessage('Code Context Notes requires a workspace folder to be opened.');
+				return;
+			}
+			const note = await noteManager.getNoteByIdGlobal(entry.noteId);
+			if (!note) {
+				vscode.window.showWarningMessage(`Note ${entry.noteId} no longer exists.`);
+				return;
+			}
+			const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(note.filePath));
+			const editor = await vscode.window.showTextDocument(doc);
+			const line = note.lineRange.start;
+			editor.revealRange(new vscode.Range(line, 0, line, 0), vscode.TextEditorRevealType.InCenter);
+			editor.selection = new vscode.Selection(line, 0, line, 0);
+		}),
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('codeContextNotes.truncateAuditLog', async () => {
+			if (!auditLog) {
+				vscode.window.showErrorMessage('Code Context Notes requires a workspace folder to be opened.');
+				return;
+			}
+			const pick = await vscode.window.showWarningMessage(
+				'Clear the agent audit log? Recorded activity will be lost; your notes are unaffected.',
+				{ modal: true },
+				'Clear log',
+			);
+			if (pick !== 'Clear log') {
+				return;
+			}
+			await auditLog.truncate();
+			agentActivityProvider?.refresh();
+		}),
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand('codeContextNotes.revertAgentOp', async (item: AgentActivityItem) => {
+			if (!noteManager) {
+				vscode.window.showErrorMessage('Code Context Notes requires a workspace folder to be opened.');
+				return;
+			}
+			const { entry } = item;
+			const note = await noteManager.getNoteByIdGlobal(entry.noteId);
+			if (!note) {
+				vscode.window.showWarningMessage(`Note ${entry.noteId} no longer exists — nothing to revert.`);
+				return;
+			}
+
+			const confirm = await vscode.window.showWarningMessage(
+				`Revert the ${entry.op} by ${entry.agent}?`,
+				{ modal: true },
+				'Revert',
+			);
+			if (confirm !== 'Revert') {
+				return;
+			}
+
+			try {
+				if (entry.op === 'create') {
+					// The reverse of a create is a delete.
+					await noteManager.deleteNote(note.id, note.filePath);
+				} else {
+					// The reverse of an edit/delete is the previous content. history
+					// is append-only, so the entry before the last is the state this
+					// op replaced.
+					const prior = note.history[note.history.length - 2];
+					if (!prior) {
+						vscode.window.showWarningMessage('No prior version recorded for this note.');
+						return;
+					}
+					const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(note.filePath));
+					await noteManager.updateNote({ id: note.id, content: prior.content }, doc);
+				}
+				agentActivityProvider?.refresh();
+				vscode.window.showInformationMessage(`Reverted ${entry.op} on ${path.basename(note.filePath)}.`);
+			} catch (e) {
+				vscode.window.showErrorMessage(`Revert failed: ${(e as Error).message}`);
+			}
+		}),
+	);
+
 	// Add Note to Selection (via command palette or keyboard shortcut)
 	const addNoteCommand = vscode.commands.registerCommand(
 		'codeContextNotes.addNote',

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -4,7 +4,7 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { StorageManager, ExportWriter, ContentHashTracker, NoteManager, SearchManager, LockManager } from '@jnahian/code-notes-core';
+import { StorageManager, ExportWriter, ContentHashTracker, NoteManager, SearchManager, LockManager, writeWorkspaceConfig } from '@jnahian/code-notes-core';
 import { GitIntegration } from './gitIntegration.js';
 import { CommentController } from './commentController.js';
 import { CodeNotesLensProvider } from './codeLensProvider.js';
@@ -65,6 +65,33 @@ export async function activate(context: vscode.ExtensionContext) {
 	const authorName = config.get<string>('authorName', '');
 	const showCodeLens = config.get<boolean>('showCodeLens', true);
 
+	// The MCP server can't read VS Code settings — it reads config.json. Treat
+	// the VS Code settings as the UI and config.json as the shared source of
+	// truth, and keep them in sync.
+	const storagePath = path.join(workspaceRoot, storageDirectory);
+	const syncWorkspaceConfig = async () => {
+		const cfg = vscode.workspace.getConfiguration('codeContextNotes');
+		await writeWorkspaceConfig(storagePath, {
+			agentWriteMode: cfg.get<'direct' | 'audit' | 'queue'>('agentWriteMode', 'audit'),
+			agentAllowList: cfg.get<string[]>('agentAllowList', []),
+			auditLogRetention: cfg.get<number>('auditLogRetention', 1000),
+		});
+	};
+
+	context.subscriptions.push(
+		vscode.workspace.onDidChangeConfiguration(async (e) => {
+			if (
+				e.affectsConfiguration('codeContextNotes.agentWriteMode') ||
+				e.affectsConfiguration('codeContextNotes.agentAllowList') ||
+				e.affectsConfiguration('codeContextNotes.auditLogRetention')
+			) {
+				// The user changed a setting, so creating the storage dir here is
+				// what they asked for.
+				await syncWorkspaceConfig();
+			}
+		}),
+	);
+
 	// Initialize components
 	const storage = new StorageManager(workspaceRoot, storageDirectory);
 	const hashTracker = new ContentHashTracker();
@@ -76,6 +103,16 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// Initialize note manager
 	noteManager = new NoteManager(storage, hashTracker, gitIntegration, { lockManager });
+
+	// Mirror the settings for the MCP server, but only once this workspace
+	// actually uses notes. writeWorkspaceConfig creates a git-visible file, and
+	// opening an unrelated project with the extension installed must not add
+	// one. (storageExists() is no use as the signal — createStorage() above
+	// makes it true everywhere.) A workspace with no config.json reads as the
+	// default mode anyway, so nothing is lost by waiting.
+	if ((await storage.getAllNoteFiles()).length > 0) {
+		await syncWorkspaceConfig();
+	}
 
 	// Initialize search manager
 	searchManager = new SearchManager(context.globalState);
@@ -1206,9 +1243,25 @@ function setupEventListeners(context: vscode.ExtensionContext) {
 	const storageDirectory = config.get<string>('storageDirectory', '.code-notes');
 	const fileWatcherPattern = new vscode.RelativePattern(
 		vscode.workspace.workspaceFolders![0],
-		`${storageDirectory}/**/*.md`
+		`${storageDirectory}/**/*.{md,log}`
 	);
 	const fileWatcher = vscode.workspace.createFileSystemWatcher(fileWatcherPattern);
+
+	// Proposals and the audit log live under the storage dir but are not notes.
+	// Route them to their own views instead of the note cache/sidebar.
+	const storagePath = path.join(vscode.workspace.workspaceFolders![0].uri.fsPath, storageDirectory);
+	const routeNonNoteFile = (uri: vscode.Uri): boolean => {
+		const rel = path.relative(storagePath, uri.fsPath);
+		if (rel.startsWith('_pending')) {
+			noteManager.emit('proposalsChanged');
+			return true;
+		}
+		if (path.basename(uri.fsPath).startsWith('_audit.log')) {
+			noteManager.emit('auditLogChanged');
+			return true;
+		}
+		return false;
+	};
 
 	// AGENTS.md is a generated export living in the same directory; treating
 	// it as a note would make export regeneration re-trigger itself forever.
@@ -1216,6 +1269,9 @@ function setupEventListeners(context: vscode.ExtensionContext) {
 
 	// When a note file is created
 	fileWatcher.onDidCreate((uri) => {
+		if (routeNonNoteFile(uri)) {
+			return;
+		}
 		if (isGeneratedExport(uri)) {
 			return;
 		}
@@ -1227,6 +1283,9 @@ function setupEventListeners(context: vscode.ExtensionContext) {
 
 	// When a note file is changed
 	fileWatcher.onDidChange((uri) => {
+		if (routeNonNoteFile(uri)) {
+			return;
+		}
 		if (isGeneratedExport(uri)) {
 			return;
 		}
@@ -1238,6 +1297,9 @@ function setupEventListeners(context: vscode.ExtensionContext) {
 
 	// When a note file is deleted
 	fileWatcher.onDidDelete((uri) => {
+		if (routeNonNoteFile(uri)) {
+			return;
+		}
 		if (isGeneratedExport(uri)) {
 			return;
 		}

--- a/packages/extension/src/pendingProposalsProvider.ts
+++ b/packages/extension/src/pendingProposalsProvider.ts
@@ -1,0 +1,41 @@
+import * as vscode from 'vscode';
+import type { Proposal, ProposalStore } from '@jnahian/code-notes-core';
+
+export class ProposalItem extends vscode.TreeItem {
+	constructor(public readonly proposal: Proposal, orphaned: boolean) {
+		super(
+			`${proposal.op} · ${vscode.workspace.asRelativePath(proposal.file)}`,
+			vscode.TreeItemCollapsibleState.None,
+		);
+		this.description = orphaned
+			? `${proposal.agent} · target missing`
+			: `${proposal.agent} · ${new Date(proposal.proposedAt).toLocaleString()}`;
+		this.tooltip = proposal.content || `(${proposal.op})`;
+		// Drives which actions the menu offers: an orphan can only be rejected.
+		this.contextValue = orphaned ? 'orphanedProposalItem' : 'proposalItem';
+		this.iconPath = new vscode.ThemeIcon(orphaned ? 'warning' : 'git-pull-request');
+	}
+}
+
+export class PendingProposalsProvider implements vscode.TreeDataProvider<ProposalItem> {
+	private _onDidChangeTreeData = new vscode.EventEmitter<ProposalItem | undefined | null | void>();
+	readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+	constructor(
+		private store: ProposalStore,
+		private isOrphaned: (p: Proposal) => Promise<boolean>,
+	) {}
+
+	refresh(): void {
+		this._onDidChangeTreeData.fire();
+	}
+
+	getTreeItem(element: ProposalItem): vscode.TreeItem {
+		return element;
+	}
+
+	async getChildren(): Promise<ProposalItem[]> {
+		const proposals = await this.store.list();
+		return Promise.all(proposals.map(async p => new ProposalItem(p, await this.isOrphaned(p))));
+	}
+}

--- a/packages/extension/src/test/suite/agentActivity.test.ts
+++ b/packages/extension/src/test/suite/agentActivity.test.ts
@@ -1,0 +1,11 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+suite('Agent activity view', () => {
+	test('registers the view and its commands', async () => {
+		const commands = await vscode.commands.getCommands(true);
+		assert.ok(commands.includes('codeContextNotes.revertAgentOp'), 'revert command registered');
+		assert.ok(commands.includes('codeContextNotes.truncateAuditLog'), 'truncate command registered');
+		assert.ok(commands.includes('codeContextNotes.openAuditedNote'), 'open command registered');
+	});
+});

--- a/packages/extension/src/test/suite/pendingProposals.test.ts
+++ b/packages/extension/src/test/suite/pendingProposals.test.ts
@@ -1,0 +1,11 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+suite('Pending proposals view', () => {
+	test('registers the approve/reject commands', async () => {
+		const commands = await vscode.commands.getCommands(true);
+		assert.ok(commands.includes('codeContextNotes.approveProposal'), 'approve registered');
+		assert.ok(commands.includes('codeContextNotes.rejectProposal'), 'reject registered');
+		assert.ok(commands.includes('codeContextNotes.editAndApproveProposal'), 'edit-and-approve registered');
+	});
+});

--- a/web/src/pages/ChangelogPage.tsx
+++ b/web/src/pages/ChangelogPage.tsx
@@ -37,8 +37,8 @@ export function ChangelogPage() {
           {/* Timeline Items */}
           <div className="space-y-16">
 
-          {/* Version 0.4.0 */}
-          <div id="v0.4.0" className="relative grid grid-cols-1 md:grid-cols-[30%_70%] gap-8 items-start">
+          {/* Version 0.5.0 */}
+          <div id="v0.5.0" className="relative grid grid-cols-1 md:grid-cols-[30%_70%] gap-8 items-start">
             {/* Timeline Node */}
             <div className="absolute left-0 md:left-[30%] transform -translate-x-1/2 top-2">
               <div className="w-4 h-4 rounded-full bg-brand-orange border-4 border-white dark:border-slate-900 shadow-lg"></div>
@@ -48,9 +48,123 @@ export function ChangelogPage() {
             <div className="pl-8 md:pl-0 md:pr-12 text-left md:text-right space-y-2">
               <div className="flex md:flex-col md:items-end items-start gap-2">
                 <h3 className="text-2xl font-bold flex items-center gap-2 md:flex-row-reverse">
-                  <span>Version 0.4.0</span>
+                  <span>Version 0.5.0</span>
                   <Badge className="bg-brand-orange">Latest</Badge>
                 </h3>
+              </div>
+              <div className="flex items-center gap-2 text-muted-foreground text-sm md:justify-end">
+                <Calendar className="h-4 w-4" />
+                <span>July 17, 2026</span>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Take control of agent-authored notes: a workspace setting picks whether agent writes land immediately, get logged, or wait for your approval, with sidebar views to review and undo them.
+              </p>
+            </div>
+
+            {/* Right Column - Changes */}
+            <div className="pl-8 md:pl-12">
+              <Card className="shadow-brand-drop bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-800 dark:to-slate-900 border-2 border-brand-orange">
+                <CardContent className="space-y-6">
+                  {/* Added */}
+                  <div>
+                    <h4 className="font-semibold mb-3 text-green-600 dark:text-green-400 flex items-center space-x-2">
+                      <Plus className="h-4 w-4" />
+                      <span>Added</span>
+                    </h4>
+                    <div className="space-y-3">
+                      <div className="flex items-start space-x-3 bg-white dark:bg-slate-800 p-3 rounded-xl">
+                        <Settings className="h-5 w-5 text-brand-orange mt-0.5 flex-shrink-0" />
+                        <div>
+                          <h5 className="font-semibold text-sm">Agent Write Modes</h5>
+                          <p className="text-sm text-muted-foreground mt-1">
+                            One setting picks how MCP-agent writes are handled, stored in <code className="bg-brand-navy text-brand-warm px-1 rounded">.code-notes/config.json</code> so the standalone server reads the same policy.
+                          </p>
+                          <ul className="text-xs text-muted-foreground mt-2 space-y-1 ml-3">
+                            <li>• <strong>direct</strong> — writes land immediately</li>
+                            <li>• <strong>audit</strong> (default) — writes land and are logged</li>
+                            <li>• <strong>queue</strong> — writes wait for your approval</li>
+                            <li>• No server flag for the mode: an agent can't pick its own rails, and a change takes effect with no restart</li>
+                          </ul>
+                        </div>
+                      </div>
+                      <div className="flex items-start space-x-3 bg-white dark:bg-slate-800 p-3 rounded-xl">
+                        <FileText className="h-5 w-5 text-brand-orange mt-0.5 flex-shrink-0" />
+                        <div>
+                          <h5 className="font-semibold text-sm">Agent Activity View + Revert</h5>
+                          <p className="text-sm text-muted-foreground mt-1">
+                            In audit mode, every agent op is logged to <code className="bg-brand-navy text-brand-warm px-1 rounded">.code-notes/_audit.log</code> and shown in a sidebar view.
+                          </p>
+                          <ul className="text-xs text-muted-foreground mt-2 space-y-1 ml-3">
+                            <li>• Inline <strong>Revert</strong>: a create reverses to a delete, an edit/delete restores from history</li>
+                            <li>• Refreshes when an agent in another process writes; the log rotates atomically with no entry lost</li>
+                          </ul>
+                        </div>
+                      </div>
+                      <div className="flex items-start space-x-3 bg-white dark:bg-slate-800 p-3 rounded-xl">
+                        <MousePointerClick className="h-5 w-5 text-brand-orange mt-0.5 flex-shrink-0" />
+                        <div>
+                          <h5 className="font-semibold text-sm">Pending Agent Proposals View</h5>
+                          <p className="text-sm text-muted-foreground mt-1">
+                            In queue mode, agent writes become proposals in <code className="bg-brand-navy text-brand-warm px-1 rounded">.code-notes/_pending/</code> instead of touching live notes.
+                          </p>
+                          <ul className="text-xs text-muted-foreground mt-2 space-y-1 ml-3">
+                            <li>• <strong>Approve / Reject / Edit-and-approve</strong>; approve records who approved it, reject keeps the file for audit</li>
+                            <li>• Simple-pick when a note changed since the proposal; orphaned proposals (target gone) can only be rejected</li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Fixed */}
+                  <div>
+                    <h4 className="font-semibold mb-3 text-green-600 dark:text-green-400 flex items-center space-x-2">
+                      <Wrench className="h-4 w-4" />
+                      <span>Fixed</span>
+                    </h4>
+                    <div className="space-y-2 text-sm">
+                      <div className="flex items-start space-x-2">
+                        <span className="text-green-500 font-bold">✓</span>
+                        <span>Note repositioning now locks and re-reads, so following an editor's changes can't overwrite a note edited concurrently by another process</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Security */}
+                  <div>
+                    <h4 className="font-semibold mb-3 text-red-600 dark:text-red-400 flex items-center space-x-2">
+                      <Shield className="h-4 w-4" />
+                      <span>Security</span>
+                    </h4>
+                    <div className="space-y-1 text-sm text-muted-foreground bg-white dark:bg-slate-800 p-3 rounded-xl">
+                      <p>• Agent-write identity comes from the writer, not the note — an agent can no longer edit or delete a human's note without approval in queue mode</p>
+                      <p>• Note content can't forge note structure: storage is now a length-delimited format, so a note body can't delete itself or fake its history on reload</p>
+                      <p>• The audit log never drops an entry under load — rotation is atomic and appends are lock-free</p>
+                    </div>
+                  </div>
+
+                  {/* Compatibility */}
+                  <div className="bg-blue-50 dark:bg-slate-800 border-l-4 border-brand-orange p-3 rounded-r-xl">
+                    <p className="text-sm text-muted-foreground">
+                      <strong>Heads up:</strong> <code className="bg-brand-navy text-brand-warm px-1 rounded">audit</code> is the new default — a workspace with notes gains a <code className="bg-brand-navy text-brand-warm px-1 rounded">config.json</code> and starts logging agent writes unless you set the mode to <code className="bg-brand-navy text-brand-warm px-1 rounded">direct</code>. Notes migrate to a new on-disk format on next save; upgrade the MCP server alongside the extension.
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+
+          {/* Version 0.4.0 */}
+          <div id="v0.4.0" className="relative grid grid-cols-1 md:grid-cols-[30%_70%] gap-8 items-start">
+            {/* Timeline Node */}
+            <div className="absolute left-0 md:left-[30%] transform -translate-x-1/2 top-2">
+              <div className="w-4 h-4 rounded-full bg-blue-500 border-4 border-white dark:border-slate-900 shadow-lg"></div>
+            </div>
+
+            {/* Left Column - Version Info */}
+            <div className="pl-8 md:pl-0 md:pr-12 text-left md:text-right space-y-2">
+              <div className="flex md:flex-col md:items-end items-start gap-2">
+                <h3 className="text-2xl font-bold">Version 0.4.0</h3>
               </div>
               <div className="flex items-center gap-2 text-muted-foreground text-sm md:justify-end">
                 <Calendar className="h-4 w-4" />
@@ -63,7 +177,7 @@ export function ChangelogPage() {
 
             {/* Right Column - Changes */}
             <div className="pl-8 md:pl-12">
-              <Card className="shadow-brand-drop bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-800 dark:to-slate-900 border-2 border-brand-orange">
+              <Card className="bg-white shadow-brand-drop">
                 <CardContent className="space-y-6">
                   {/* Added */}
                   <div>

--- a/web/src/pages/ChangelogPage.tsx
+++ b/web/src/pages/ChangelogPage.tsx
@@ -127,6 +127,10 @@ export function ChangelogPage() {
                         <span className="text-green-500 font-bold">✓</span>
                         <span>Note repositioning now locks and re-reads, so following an editor's changes can't overwrite a note edited concurrently by another process</span>
                       </div>
+                      <div className="flex items-start space-x-2">
+                        <span className="text-green-500 font-bold">✓</span>
+                        <span>Reverting an agent's delete restores the note; empty-content notes survive reload; approved edits record who approved them; a restore is logged as its own action</span>
+                      </div>
                     </div>
                   </div>
 
@@ -140,6 +144,7 @@ export function ChangelogPage() {
                       <p>• Agent-write identity comes from the writer, not the note — an agent can no longer edit or delete a human's note without approval in queue mode</p>
                       <p>• Note content can't forge note structure: storage is now a length-delimited format, so a note body can't delete itself or fake its history on reload</p>
                       <p>• The audit log never drops an entry under load — rotation is atomic and appends are lock-free</p>
+                      <p>• A proposal's file value can't split its frontmatter — the free-text fields are JSON-encoded, the last spot the "content can't forge structure" invariant wasn't mirrored</p>
                     </div>
                   </div>
 


### PR DESCRIPTION
## Summary

v0.5 puts humans in control of what MCP coding agents write to workspace notes. A single workspace setting picks how agent writes are handled — `direct` (land immediately), `audit` (land + get logged, the new default), or `queue` (wait for approval) — with two sidebar views for reviewing and undoing agent activity.

Implements all 12 tasks of `docs/superpowers/plans/2026-07-17-agent-integration-v0.5-trust-model.md`.

> **Stacked on #57 (v0.4).** This PR targets `feat/v0.4-mcp-server` so the diff shows only the v0.5 changes. Merge #57 first, then retarget this at `main`.

## What's in it

- **Agent write modes** (`codeContextNotes.agentWriteMode`) in `.code-notes/config.json` — a workspace-owned file both the extension and the standalone MCP server read. No server flag for the mode: an agent that picks its own rails has none. The server re-reads it per call, so a change needs no restart.
- **`audit` mode + Agent activity view** — every agent op appends to `.code-notes/_audit.log`; the sidebar lists them with an inline **Revert** (create→delete, edit→prior content, delete→restore) and a Truncate command. The log rotates atomically, losing nothing under concurrent writes.
- **`queue` mode + Pending agent proposals view** — agent writes become proposals in `.code-notes/_pending/`; tools return `{ "status": "pending" }` (a success shape, not an error). Approve / Reject / Edit-and-approve, with simple-pick for a note changed since the proposal and orphan handling for a deleted target.

## Security — found and fixed during implementation

An independent trust-boundary audit and adversarial testing turned up defects the trust model depends on:

- **Agent-write identity comes from the writer, not the note.** An earlier cut let an agent edit or delete any *human*-authored note in `queue` mode with no approval. Identity is now a property of the writer (server = agent, extension = human), fail-closed.
- **Note content can't forge note structure.** Content is agent-controlled input, and the markdown format used unescaped delimiters — a note whose body was `**Status:** DELETED` deleted itself and forged history on reload, poisoning Revert. Storage is now a versioned, length-delimited format (`**Format:** 2`); pre-v0.5 notes read via the legacy parser and migrate on next save.
- **The audit log never drops an entry under load** — rotation is atomic (rename, not rewrite), appends are lock-free.
- **`updateNoteMetadata`, `updateNotePositions`, `undeleteNote` fail closed for agent writers** so a future agent tool can't bypass the rails.

Every fix is reproduced, then mutation-checked. A frozen pre-v0.5 note gates the format migration. A final whole-branch review (independent agent) verified the trust router is airtight and the v2 parser resists forgery under direct adversarial testing, and signed off **Ready to merge** after the one issue it found — a broken delete-revert — was fixed.

## Review follow-ups (folded in)

The final whole-branch review's four non-blocking items were fixed before release rather than deferred: approved-edit attribution (`approvedBy`), a named `restored` history action, proposal-frontmatter hardening (JSON-encoded scalars), and empty-content notes surviving reload. Each is TDD'd and mutation-checked.

## Compatibility

- **`audit` is the new default** — a workspace with notes gains a `config.json` and starts logging agent writes unless set to `direct`. A workspace with no notes is untouched.
- **Notes migrate to the v2 on-disk format on next save**; existing notes read unchanged until then.
- **Upgrade the MCP server alongside the extension** — a v0.4 server against a v0.5 workspace behaves as `direct`.

## Testing

438 tests, all green: core 167, MCP server 74, extension 19 unit + 178 integration. `code-context-notes-0.5.0.vsix` packages (12 files, 45.5 KB). Publish dry-runs clean for both npm packages (core/mcp 0.2.0); packed tarballs smoke-tested through the real queue flow.

## Not published

Nothing published to npm or the marketplace — that awaits explicit approval. Deferred non-blocking follow-ups are recorded in `docs/agent-trust-model/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

