### PR TITLE
🐛 fix(extension): declare all sidebar sortBy values in the setting enum

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -539,10 +539,17 @@
         "codeContextNotes.sidebar.sortBy": {
           "type": "string",
           "enum": [
-            "file"
+            "file",
+            "date",
+            "author"
+          ],
+          "enumDescriptions": [
+            "Alphabetically by file path",
+            "Most recently updated notes first",
+            "By author name, then file path"
           ],
           "default": "file",
-          "description": "Sort notes by file path"
+          "description": "How to sort files in the Notes sidebar"
         },
         "codeContextNotes.exports.enabled": {
           "type": "boolean",


### PR DESCRIPTION
## Summary

`codeContextNotes.sidebar.sortBy` declared its `enum` as `["file"]` only, so the VS Code Settings UI dropdown never offered `date` or `author` — even though `notesSidebarProvider.ts` already implements all three sorts. Users could only pick `date`/`author` by hand-editing `settings.json`.

## Change

Add `date` and `author` to the enum with `enumDescriptions` matching the actual behavior:

- `file` — alphabetically by file path
- `date` — most recently updated notes first
- `author` — by author name, then file path

No code change needed — the switch in `notesSidebarProvider.ts` already handles all three. Manifest JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)